### PR TITLE
Force three-argument lambdas/procs

### DIFF
--- a/lib/traject/indexer.rb
+++ b/lib/traject/indexer.rb
@@ -164,13 +164,8 @@ class Traject::Indexer
       # with same accumulator.
       [index_step[:lambda], index_step[:block]].each do |aProc|
         if aProc
-          case aProc.arity
-          when 1 then aProc.call(record)
-          when 2 then aProc.call(record, accumulator)
-          else        aProc.call(record, accumulator, context)
-          end
+          aProc.call(record, accumulator, context)
         end
-
       end
 
       (context.output_hash[field_name] ||= []).concat accumulator

--- a/test/indexer/map_record_test.rb
+++ b/test/indexer/map_record_test.rb
@@ -20,7 +20,7 @@ describe "Traject::Indexer#map_record" do
     it "works with block" do
       called  = false
 
-      @indexer.to_field("title") do |record, accumulator|
+      @indexer.to_field("title") do |record, accumulator, context|
         assert_kind_of MARC::Record, record
         assert_kind_of Array, accumulator
 
@@ -38,7 +38,7 @@ describe "Traject::Indexer#map_record" do
     it "works with a lambda arg" do
       called  = false
 
-      logic = lambda do |record, accumulator|
+      logic = lambda do |record, accumulator, context|
         assert_kind_of MARC::Record, record
         assert_kind_of Array, accumulator
 
@@ -58,11 +58,11 @@ describe "Traject::Indexer#map_record" do
     it "works with both lambda and Proc" do
       block_called = false
 
-      lambda_arg = lambda do |record, accumulator|
+      lambda_arg = lambda do |record, accumulator, context|
         accumulator << "Lambda-provided Value"
       end
 
-      @indexer.to_field("title", lambda_arg) do |record, accumulator|
+      @indexer.to_field("title", lambda_arg) do |record, accumulator, context|
         assert_includes accumulator, "Lambda-provided Value"
         accumulator << "Block-provided Value"
 


### PR DESCRIPTION
Change code and tests to always use three-argument lambdas (record, accumulator, context). Having a single, consistent signature will make the creation of macros and other custom code less error-prone.
