### PR TITLE
Have JsonWriter open file in write mode

### DIFF
--- a/lib/traject/json_writer.rb
+++ b/lib/traject/json_writer.rb
@@ -34,7 +34,7 @@ class Traject::JsonWriter
     unless defined? @output_file
       @output_file = 
         if settings["output_file"]
-          File.open(settings["output_file"])
+          File.open(settings["output_file"], 'w:UTF-8')
         elsif settings["output_stream"]
           settings["output_stream"]
         else


### PR DESCRIPTION
JsonWriter currently doesn't open the file in write mode. Setting it to open in write mode with UTF-8 encoding.
