### PR TITLE
Make each_record take a description

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,8 +247,12 @@ There is also a method `each_record`, which is like `to_field`, but without
 a specific field. It can be used for other side-effects of your choice, or
 even for writing to multiple fields.
 
+It's first argument (parallel to the field name in `to_field`) is 
+descritive only, but helps document the code and shows up in the `context.field_name` 
+for use in logging and debugging.
+
 ~~~ruby
-  each_record do |record, context|
+  each_record("Fill one_field and another_field") do |record, context|
     # example of writing to two fields at once.
     (x, y) = Something.do_stuff
     (context["one_field"] ||= [])     << x

--- a/lib/traject/indexer.rb
+++ b/lib/traject/indexer.rb
@@ -165,17 +165,27 @@ class Traject::Indexer
     }
   end
 
-  def each_record(aLambda = nil, &block)
+  # Process that runs each on each record but does *not* result in anything being
+  # mapped to a field.
+  #
+  # Useful for external size-effect (e.g., logging) and for avoiding repeated work
+  # by memoizing results and sticking them in the context object
+  #
+  # Format is the same as a to_field. The "field" (name/description) is 
+  # available for logging purposes and to self-document the index settings
+  
+  def each_record(desc, aLambda = nil, &block)
     # arity check
     [aLambda, block].each do |proc|
       # allow negative arity, meaning variable/optional, trust em on that.
       # but for positive arrity, we need 1 or 2 args
       if proc && (proc.arity == 0 || proc.arity > 2)
-        raise ArgumentError.new("block/proc given to to_field needs 1 or 2 arguments: #{proc}")
+        raise ArgumentError.new("block/proc given to each_record needs 1 or 2 arguments: #{proc}")
       end
     end
 
     @index_steps << {
+      :field_name => desc.to_s,
       :lambda => aLambda,
       :block  => block,
       :type   => :each_record

--- a/test/indexer/each_record_test.rb
+++ b/test/indexer/each_record_test.rb
@@ -8,26 +8,26 @@ describe "Traject::Indexer#each_record" do
   describe "checks arguments" do
     it "rejects no-arg block" do
       assert_raises(ArgumentError) do
-        @indexer.each_record do
+        @indexer.each_record("no block") do
         end
       end
     end
     it "rejects three-arg block" do
       assert_raises(ArgumentError) do
-        @indexer.each_record do |one, two, three|
+        @indexer.each_record("three args") do |one, two, three|
         end
       end
     end
     it "accepts one-arg block" do
-      @indexer.each_record do |record|
+      @indexer.each_record("one arg") do |record|
       end
     end
     it "accepts two-arg block" do
-      @indexer.each_record do |record, context|
+      @indexer.each_record("two args") do |record, context|
       end
     end
     it "accepts variable arity block" do
-      @indexer.each_record do |*variable|
+      @indexer.each_record("three args") do |*variable|
       end
     end
   end

--- a/test/indexer/map_record_test.rb
+++ b/test/indexer/map_record_test.rb
@@ -121,7 +121,7 @@ describe "Traject::Indexer#map_record" do
   describe "#each_record" do
     it "is called with one-arg record" do
       called = false
-      @indexer.each_record do |record|
+      @indexer.each_record("Check that it's called") do |record|
         called = true
         assert_kind_of MARC::Record, record
       end
@@ -131,7 +131,7 @@ describe "Traject::Indexer#map_record" do
     end
     it "is called with two-arg record and context" do
       called = false
-      @indexer.each_record do |record, context|
+      @indexer.each_record("two-arg and context") do |record, context|
         called = true
         assert_kind_of MARC::Record, record
         assert_kind_of Traject::Indexer::Context, context
@@ -146,7 +146,7 @@ describe "Traject::Indexer#map_record" do
         context.output_hash["field"] << "first"
       end
 
-      @indexer.each_record(lambda_arg) do |record, context|
+      @indexer.each_record("Called with lambda", lambda_arg) do |record, context|
         context.output_hash["field"] ||= []
         context.output_hash["field"] << "second"
       end
@@ -157,7 +157,7 @@ describe "Traject::Indexer#map_record" do
     end
     it "is called in order with #to_field" do
       @indexer.to_field("foo") {|record, accumulator| accumulator << "first"}
-      @indexer.each_record {|record, context| context.output_hash["foo"] << "second" }
+      @indexer.each_record("Add second as side effect") {|record, context| context.output_hash["foo"] << "second" }
       @indexer.to_field("foo") {|record, accumulator| accumulator << "third"}
 
       output = @indexer.map_record(@record)


### PR DESCRIPTION
Change the `each_record` syntax to take a description (parallel to the field name in `to_field`) for self-documenting indexing code and to make the description available for logging/debugging in the `context.field_name` within the applied lambda.

``` ruby

to_field('id) ->(a,b,c) { ...do whatever }
each_record("Prep titles for title work") do ...end
to_field('title_ab') ->(a,b,c) { ... }

```

Changed syntax, tests, and the README.md file.
