### PR TITLE
Better parse errors

### DIFF
--- a/test/indexer/each_record_test.rb
+++ b/test/indexer/each_record_test.rb
@@ -7,13 +7,13 @@ describe "Traject::Indexer#each_record" do
 
   describe "checks arguments" do
     it "rejects no-arg block" do
-      assert_raises(ArgumentError) do
+      assert_raises(Traject::Indexer::ArityError) do
         @indexer.each_record do
         end
       end
     end
     it "rejects three-arg block" do
-      assert_raises(ArgumentError) do
+      assert_raises(Traject::Indexer::ArityError) do
         @indexer.each_record do |one, two, three|
         end
       end
@@ -30,5 +30,30 @@ describe "Traject::Indexer#each_record" do
       @indexer.each_record do |*variable|
       end
     end
+
+    it "finds first (only) field on each_record error" do
+      begin
+        @indexer.to_field('foo') {|one, two| }
+        @indexer.each_record {|one, two, three| }   # bad arity
+        flunk("Should have rejected bad arity ")
+      rescue Traject::Indexer::ArityError => e
+        assert_match(/foo/, e.message)
+      rescue 
+        flunk("Should only fail with a ArityError")
+      end
+    end
+    
+    it "rejects each_record with a name (e.g., using a to_field syntax)" do
+      assert_raises(Traject::Indexer::NamingError) do
+        @indexer.each_record('bad_name') {|one, two| }
+      end
+    end
+    
+    it "reject each_record with no arguments/blocks at all" do
+      assert_raises(ArgumentError) do
+        @indexer.each_record()
+      end
+    end
+
   end
 end

--- a/test/indexer/to_field_test.rb
+++ b/test/indexer/to_field_test.rb
@@ -6,20 +6,23 @@ describe "Traject::Indexer.to_field" do
   end
   describe "checks it's arguments" do
     it "rejects nil first arg" do
-      assert_raises(ArgumentError) { @indexer.to_field(nil) }
+      assert_raises(Traject::Indexer::NamingError) { @indexer.to_field(nil) }
     end
     it "rejects empty string first arg" do
-      assert_raises(ArgumentError) {@indexer.to_field("")}
+      assert_raises(Traject::Indexer::NamingError) {@indexer.to_field("")}
     end
+    it "rejects non-string first arg" do
+      assert_raises(Traject::Indexer::NamingError) {@indexer.to_field(:symbol)}
+    end
+    
     it "rejects one-arg lambda" do
-      assert_raises(ArgumentError) do
+      assert_raises(Traject::Indexer::ArityError) do
         @indexer.to_field("foo") do |one_arg|
-
         end
       end
     end
     it "rejects four-arg lambda" do
-      assert_raises(ArgumentError) do 
+      assert_raises(Traject::Indexer::ArityError) do 
         @indexer.to_field("foo") do |one_arg, two_arg, three_arg, four_arg|
         end
       end
@@ -35,6 +38,32 @@ describe "Traject::Indexer.to_field" do
       @indexer.to_field("foo") do |*variable|
       end
     end
-    
   end
+  
+  describe "gives location in error message" do
+
+    it "finds no previous field on initial error" do
+      begin
+        @indexer.to_field('') {|one, two| }   # bad field name
+        flunk("Should have rejected empty field name")
+      rescue Traject::Indexer::NamingError => e
+        assert_match(/no previous named fields/, e.message)
+      rescue 
+        flunk("Should only fail with a NamingError")
+      end
+    end
+
+    it "finds first (only) field on error" do
+      begin
+        @indexer.to_field('foo') {|one, two| }
+        @indexer.to_field('') {|one, two| }   # bad field name
+        flunk("Should have rejected empty field name")
+      rescue Traject::Indexer::NamingError => e
+        assert_match(/foo/, e.message)
+      rescue 
+        flunk("Should only fail with a NamingError")
+      end
+    end
+  end
+  
 end


### PR DESCRIPTION
Extract #to_field / #each_record syntax and semantics checking into several methods and make the resulting error messages slightly better (by including the name of the field being parse, or the name of the last-named-field successfully parsed).
