### PR TITLE
Allows specs to be an array of (optionally colon-delimited) values

### DIFF
--- a/lib/traject/marc_extractor.rb
+++ b/lib/traject/marc_extractor.rb
@@ -63,7 +63,7 @@ module Traject
     # Converts from a string marc spec like "245abc:700a" to a nested hash used internally
     # to represent the specification.
     #
-    # a String specification is a string of form:
+    # a String specification is a string (or array of strings) of form:
     #  {tag}{|indicators|}{subfields} seperated by colons
     # tag is three chars (usually but not neccesarily numeric),
     # indicators are optional two chars prefixed by hyphen,
@@ -95,8 +95,9 @@ module Traject
     # See tests for more examples.
     def self.parse_string_spec(spec_string)
       hash = {}
+      spec_strings = spec_string.is_a?(Array) ? spec_string.map{|s| s.split(/\s*:\s*/)}.flatten : spec_string.split(/s*:\s*/)
 
-      spec_string.split(":").each do |part|
+      spec_strings.each do |part|
         if (part =~ /\A([a-zA-Z0-9]{3})(\|([a-z0-9\ \*]{2})\|)?([a-z0-9]*)?\Z/)
           # variable field
           tag, indicators, subfields = $1, $3, $4

--- a/test/marc_extractor_test.rb
+++ b/test/marc_extractor_test.rb
@@ -50,6 +50,27 @@ describe "Traject::MarcExtractor" do
       assert_equal 5, parsed["005"][:bytes]
       assert_equal 7..10, parsed["008"][:bytes]
     end
+    
+    it "allows arrays of specs" do
+      parsed = Traject::MarcExtractor.parse_string_spec %w(
+        245abcde
+        810
+        700|*4|bcd
+      )
+      assert_length 3, parsed
+    end
+    
+    it "allows mixture of array and colon-delimited specs" do
+      parsed = Traject::MarcExtractor.parse_string_spec %w(
+        245abcde
+        100:110:111
+        810
+        700|*4|bcd
+      )
+      assert_length 6, parsed
+    end
+      
+    
   end
 
   # Mostly an internal method, not neccesarily API, but


### PR DESCRIPTION
Allow argument to extract_marc (actually, parse_string_spec) to take an array or strings. Also relaxes the colon-delimited requirement to allow spaces around the colons.

This will allow stuff like the following:

``` ruby
to_field 'foo', extract_marc %w(
        245abcde
        810
        700|*4|bcd
)

to_field('bar'), extract_marc %w( 
       245abcde
       100:110:111
       810
       700|*4|bcd
)

```
