### PR TITLE
Keep marc4j record for later

### DIFF
--- a/test/marc4j_reader_test.rb
+++ b/test/marc4j_reader_test.rb
@@ -75,4 +75,14 @@ describe "Marc4JReader" do
     assert first['245']['a'].encoding.name, "UTF-8"
     assert_equal "Fikr-i Ayāz /", first['245']['a']
   end
+  
+  it "keeps marc4j object when asked" do
+    file = File.new(support_file_path "test_data.utf8.marc.xml")
+    settings = Traject::Indexer::Settings.new("marc_source.type" => "xml", 'marc4j_reader.keep_marc4j' => true)
+    record = Traject::Marc4JReader.new(file, settings).to_a.first
+    assert_kind_of MARC::Record, record
+    assert_kind_of Java::org.marc4j.marc.impl::RecordImpl, record.original_marc4j
+  end
+    
+  
 end


### PR DESCRIPTION
Yeah, I know, you're gonna _love_ this one.

Some of us -- not you, I know, but some of us -- have code left over from our solrmarc days that take in a marc4j record. It costs essentially _nothing_ to hang onto the original marc4j record and create an accessor for it.

There's a complexity cost, of course -- monkey-patching MARC::Record to have an accessor called `original_marc4j` and yet another settings switch (which I went ahead and called `marc4j_reader.keep_marc4j`).

On the one hand, it's ugly. On the other, I'd really like to get a bunch of uptake, and right now that means getting people to switch over from solrmarc.  On the other-other, it's not very intrusive and unless you turn it on, you'll never know it's there.
