### PR TITLE
Added accumulator.compact! before adding to output_hash

### DIFF
--- a/lib/traject/indexer.rb
+++ b/lib/traject/indexer.rb
@@ -226,6 +226,7 @@ class Traject::Indexer
             end
           end
         end
+        accumulator.compact!
         (context.output_hash[context.field_name] ||= []).concat accumulator unless accumulator.empty?
         context.field_name = nil
 


### PR DESCRIPTION
A tiny little commit that compacts the accumulator before adding it to the `context.output_hash`. Based on my idea that de-duplification is up to the person writing the code, but no one wants to index a `nil` and shouldn't have to watch out for it themselves.
