### PR TITLE
Move dedup of languages to post-translation

### DIFF
--- a/lib/traject/macros/marc21_semantics.rb
+++ b/lib/traject/macros/marc21_semantics.rb
@@ -135,9 +135,10 @@ module Traject::Macros
             end.flatten
           end
         end
-        codes = codes.uniq
 
         translation_map.translate_array!(codes)
+        
+        codes.uniq!
 
         accumulator.concat codes
       end


### PR DESCRIPTION
Move the call to uniq to _after_ the application of the translation map, for those cases when multiple codes map onto the same language or for when the translated code is repeated in the 041
