### PR TITLE
Add explicit options checks to marc21 macros

### DIFF
--- a/test/indexer/macros_marc21_test.rb
+++ b/test/indexer/macros_marc21_test.rb
@@ -75,6 +75,15 @@ describe "Traject::Macros::Marc21" do
       
     end
     
+    it "fails on an extra/misspelled argument to extract_marc" do
+      assert_raises(RuntimeError) do
+        @indexer.instance_eval do
+          to_field "foo", extract_marc("9999", :misspelled => "Who cares")
+        end
+      end
+    end
+      
+    
       
 
     it "Marc21::trim_punctuation class method" do


### PR DESCRIPTION
Explicitly list the valid options for the extract_\* methods and throw an error if you misspell something, use a string, etc. instead of silently failing. Useful for people who can't spell "separate" :-)
