### PR TITLE
Double oclc

### DIFF
--- a/lib/traject/macros/marc21_semantics.rb
+++ b/lib/traject/macros/marc21_semantics.rb
@@ -26,15 +26,23 @@ module Traject::Macros
         accumulator.concat list.uniq if list
       end
     end
+   
     # If a num begins with a known OCLC prefix, return it without the prefix.
     # otherwise nil.
+    #
+    # Allow (OCoLC) and/or ocn/ocm/on 
+    
+    OCLCPAT = /
+      \A\s*
+      (?:(?:\(OCoLC\)) |
+         (?:\(OCoLC\))?(?:(?:ocm)|(?:ocn)|(?:on))
+         )(\d+)
+         /x
+         
     def self.oclcnum_extract(num)
-      stripped = num.gsub /\A\s*(?:\(OCoLC\))?(?:(?:ocm)|(?:ocn)|(?:on))/, ''
-      if num != stripped
-        # it had the prefix, which we've now stripped
-        return stripped
+      if OCLCPAT.match(num)
+        return $1
       else
-        # it didn't have the prefix
         return nil
       end
     end

--- a/test/indexer/macros_marc21_semantics_test.rb
+++ b/test/indexer/macros_marc21_semantics_test.rb
@@ -32,14 +32,21 @@ describe "Traject::Macros::Marc21Semantics" do
     assert_equal({}, @indexer.map_record(empty_record))
   end
   
-  it "deals with double-prefixed OCLC nunbers" do
+  it "deals with all prefixed OCLC nunbers" do
     @record.append(MARC::DataField.new('035', ' ', ' ', ['a', '(OCoLC)ocm111111111']))
+    @record.append(MARC::DataField.new('035', ' ', ' ', ['a', '(OCoLC)222222222']))
+    @record.append(MARC::DataField.new('035', ' ', ' ', ['a', 'ocm333333333']))
+    @record.append(MARC::DataField.new('035', ' ', ' ', ['a', 'ocn444444444']))
+    @record.append(MARC::DataField.new('035', ' ', ' ', ['a', '(OCoLC)ocn555555555']))
+    @record.append(MARC::DataField.new('035', ' ', ' ', ['a', '(OCoLC)on666666666']))
+    @record.append(MARC::DataField.new('035', ' ', ' ', ['a', '777777777'])) # not OCLC number
+    
     @indexer.instance_eval do
       to_field "oclcnum", oclcnum
     end
     output = @indexer.map_record(@record)
 
-    assert_equal %w{47971712 111111111},  output["oclcnum"]
+    assert_equal %w{47971712 111111111 222222222 333333333 444444444 555555555 666666666},  output["oclcnum"]
   end
     
   


### PR DESCRIPTION
Some morons have "double-prefixed" OCLC numbers of the form `(OCoLC)ocm12345678`. This small patch and test changes the regex replacement to allow this case.
