### PR TITLE
DRY source_record_id in Context where it belongs

### DIFF
--- a/lib/traject/solr_json_writer.rb
+++ b/lib/traject/solr_json_writer.rb
@@ -148,7 +148,7 @@ class Traject::SolrJsonWriter
       else
         msg = "Solr error response: #{resp.status}: #{resp.body}"
       end
-      logger.error "Could not add record #{record_id_from_context c} at source file position #{c.position}: #{msg}"
+      logger.error "Could not add record #{c.source_record_id} at source file position #{c.position}: #{msg}"
       logger.debug(c.source_record.to_s)
 
       @skipped_record_incrementer.increment
@@ -165,20 +165,6 @@ class Traject::SolrJsonWriter
   def logger
     settings["logger"] ||= Yell.new(STDERR, :level => "gt.fatal") # null logger
   end
-
-  # Returns MARC 001, then a slash, then output_hash["id"] -- if both
-  # are present. Otherwise may return just one, or even an empty string.
-  def record_id_from_context(context)
-    marc_id = if context.source_record &&
-                 context.source_record.kind_of?(MARC::Record) &&
-                 context.source_record['001']
-      context.source_record['001'].value
-    end
-    output_id = context.output_hash["id"]
-
-    return [marc_id, output_id].compact.join("/")
-  end
-
 
   # On close, we need to (a) raise any exceptions we might have, (b) send off
   # the last (possibly empty) batch, and (c) commit if instructed to do so

--- a/test/indexer/context_test.rb
+++ b/test/indexer/context_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+describe "Traject::Indexer::Context" do
+
+  describe "source_record_id" do
+    before do
+      @record = MARC::Reader.new(support_file_path('test_data.utf8.mrc')).first
+      @context = Traject::Indexer::Context.new
+      @record_001 = "   00282214 " # from the mrc file
+    end
+
+    it "gets it from 001" do
+      @context.source_record = @record
+      assert_equal @record_001, @context.source_record_id
+    end
+
+    it "gets it from the id" do
+      @context.output_hash['id'] = 'the_record_id'
+      assert_equal 'the_record_id', @context.source_record_id
+    end
+
+    it "gets from the id with non-MARC source" do
+      @context.source_record = Object.new
+      @context.output_hash['id'] = 'the_record_id'
+      assert_equal 'the_record_id', @context.source_record_id
+    end
+
+    it "gets it from both 001 and id" do
+      @context.output_hash['id'] = 'the_record_id'
+      @context.source_record = @record
+      assert_equal [@record_001, 'the_record_id'].join('/'), @context.source_record_id
+    end
+  end
+
+end

--- a/test/solr_json_writer_test.rb
+++ b/test/solr_json_writer_test.rb
@@ -215,34 +215,5 @@ describe "Traject::SolrJsonWriter" do
       assert_equal "http://example.com/solr/update", @writer.determine_solr_update_url
     end
   end
-  
-  describe "Record id from context" do
-    before do
-      @record = MARC::Reader.new(support_file_path('test_data.utf8.mrc')).first
-      @context = Traject::Indexer::Context.new
-      @writer = create_writer
-      @record_001 = "   00282214 " # from the mrc file
-    end
-      
-    it "gets it from 001" do
-      @context.source_record = @record
-      assert_equal @record_001, @writer.record_id_from_context(@context)
-    end
-    
-    it "gets it from the id" do
-      @context.output_hash['id'] = 'the_record_id'
-      assert_equal 'the_record_id', @writer.record_id_from_context(@context)
-    end
-    
-    it "gets it from both 001 and id" do
-      @context.output_hash['id'] = 'the_record_id'
-      @context.source_record = @record
-      assert_equal [@record_001, 'the_record_id'].join('/'), @writer.record_id_from_context(@context)
-    end
-      
-    
-    
-  end
-
 
 end


### PR DESCRIPTION
Tell don't ask, it belongs in Context, and now it's DRY between
indexer and writer (and future needs).

This did require me to rearrange Indexer a bit, creating
the context outside the thread, so it would be available
when I needed it for batch logging. (Alternately batch
logging could have been moved inside the thread?). I think
this is just fine, and even makes the code cleaner, but now
I'm getting paranoid that every change might be a perf regression.
I think it's fine though.