### PR TITLE
Indexer#load_config_file method

### DIFF
--- a/lib/traject/command_line.rb
+++ b/lib/traject/command_line.rb
@@ -176,8 +176,11 @@ module Traject
           self.console.puts "Could not read configuration file '#{conf_path}', exiting..."
           exit 2
         rescue Traject::Indexer::ConfigLoadError => e
+          self.console.puts "\n"
           self.console.puts e.message
           self.console.puts e.config_file_backtrace
+          self.console.puts "\n"
+          self.console.puts "Exiting..."
           exit 3
         end
       end

--- a/lib/traject/indexer.rb
+++ b/lib/traject/indexer.rb
@@ -697,15 +697,19 @@ class Traject::Indexer
   #
   # Original config path in #config_file, and line number in config
   # file that triggered the exception in #config_file_lineno (may be nil)
+  #
+  # A filtered backtrace just DOWN from config file (not including trace
+  # from traject loading config file itself) can be found in
+  # #config_file_backtrace
   class ConfigLoadError < StandardError
     # We'd have #cause in ruby 2.1, filled out for us, but we want
     # to work before then, so we use our own 'original'
-    attr_reader :original, :config_file, :config_file_lineno
+    attr_reader :original, :config_file, :config_file_lineno, :config_file_backtrace
     def initialize(config_file_path, original_exception)
-      @original           = original_exception
-      @config_file        = config_file_path
-      @config_file_lineno = Traject::Util.backtrace_lineno_for_config(config_file_path, original_exception)
-
+      @original               = original_exception
+      @config_file            = config_file_path
+      @config_file_lineno     = Traject::Util.backtrace_lineno_for_config(config_file_path, original_exception)
+      @config_file_backtrace  = Traject::Util.backtrace_from_config(config_file_path, original_exception)
       message = "Error processing configuration file #{self.config_file}:#{self.config_file_lineno} : #{original_exception.class}, #{original_exception.message}"
 
       super(message)

--- a/lib/traject/indexer.rb
+++ b/lib/traject/indexer.rb
@@ -687,6 +687,9 @@ class Traject::Indexer
   # Raised by #load_config_file when config file can not
   # be processed. 
   #
+  # The exception #message includes an error message formatted
+  # for good display to the developer, in the console. 
+  #
   # Original exception raised when processing config file
   # can be found in #original. Original exception should ordinarily
   # have a good stack trace, including the file path of the config
@@ -707,7 +710,7 @@ class Traject::Indexer
       @config_file            = config_file_path
       @config_file_lineno     = Traject::Util.backtrace_lineno_for_config(config_file_path, original_exception)
       @config_file_backtrace  = Traject::Util.backtrace_from_config(config_file_path, original_exception)
-      message = "Error processing configuration file #{self.config_file}:#{self.config_file_lineno} : #{original_exception.class}, #{original_exception.message}"
+      message = "Error loading configuration file #{self.config_file}:#{self.config_file_lineno} #{original_exception.class}:#{original_exception.message}"
 
       super(message)
     end

--- a/lib/traject/indexer.rb
+++ b/lib/traject/indexer.rb
@@ -94,17 +94,14 @@ end
 # on disk is that these config files could also be used with the standard
 # traject command line.
 #
-#      File.open(path_to_config) do |file|
-#        indexer.instance_eval(file_read.read, path_to_config)
-#      end
+#      indexer.load_config_file(path_to_config)
 #
-# That second argument repeating path_to_config ensures that stack traces
-# from config files will properly include config file locations.
-# The instance_eval may raise virtually any exception that is raised when
-# evaluating the config file. It might be wise to rescue both StandardError and
-# SyntaxError exception superclasses, to catch problems evaluating the config file.
+# This may raise if the file is not readable. Or if the config file
+# can't be evaluated, it will raise a Traject::Indexer::ConfigLoadError
+# with a bunch of contextual information useful to reporting to developer. 
 #
-# You can also instead, or in addition, write configuration inline:
+# You can also instead, or in addition, write configuration inline using
+# standard ruby `instance_eval`:
 #
 #     indexer.instance_eval do
 #        to_field "something", literal("something")
@@ -187,8 +184,8 @@ class Traject::Indexer
   #
   # Can raise:
   # * Errno::ENOENT or Errno::EACCES if file path is not accessible
-  # * Traject::Indexer::LoadConfigError if exception is raised evaluating
-  #   the config. A LoadConfigError has information in it about original
+  # * Traject::Indexer::ConfigLoadError if exception is raised evaluating
+  #   the config. A ConfigLoadError has information in it about original
   #   exception, and exactly what config file and line number triggered it.  
   def load_config_file(file_path)
     File.open(file_path) do |file|

--- a/test/indexer/load_config_file_test.rb
+++ b/test/indexer/load_config_file_test.rb
@@ -1,0 +1,89 @@
+require 'test_helper'
+require 'tempfile'
+
+describe "Traject::Indexer#load_config_path" do
+  before do
+    @indexer = Traject::Indexer.new
+  end
+
+  describe "with bad path" do
+    it "raises ENOENT on non-existing path" do
+      assert_raises(Errno::ENOENT) { @indexer.load_config_file("does/not/exist.rb") }
+    end
+    it "raises EACCES on non-readable path" do
+      file = Tempfile.new('traject_test')
+      FileUtils.chmod("ugo-r", file.path)
+
+      assert_raises(Errno::EACCES) { @indexer.load_config_file(file.path) }
+
+      file.unlink
+    end
+  end
+
+  describe "with good config" do
+    before do
+      @config_file = tmp_config_file_with(%Q{
+        settings do
+          provide "our_key", "our_value"
+        end
+        to_field "literal", literal("literal")
+      })      
+    end
+    after do
+      @config_file.unlink
+    end
+    it "loads config file by path" do
+      @indexer.load_config_file(@config_file.path)
+
+      assert_equal "our_value", @indexer.settings["our_key"]
+    end
+  end
+
+  describe "with error in config" do
+    after do
+      @config_file.unlink if @config_file
+    end
+
+    it "raises good error on SyntaxError type" do
+      @config_file = tmp_config_file_with(%Q{
+        puts "foo"
+        # Intentional syntax error missing comma
+        to_field "foo" extract_marc("245")
+      }) 
+
+      e = assert_raises(Traject::Indexer::ConfigLoadError) do
+        @indexer.load_config_file(@config_file.path)
+      end
+
+      assert_kind_of SyntaxError, e.original
+      assert_equal @config_file.path, e.config_file
+      assert_equal 4,  e.config_file_lineno
+    end
+
+    it "raises good error on StandardError type" do
+      @config_file = tmp_config_file_with(%Q{
+        # Intentional non-syntax error, bad extract_marc spec
+        to_field "foo", extract_marc("#%^%^%^")
+      }) 
+
+      e = assert_raises(Traject::Indexer::ConfigLoadError) do
+        @indexer.load_config_file(@config_file.path)
+      end
+
+      assert_kind_of StandardError, e.original
+      assert_equal @config_file.path, e.config_file
+      assert_equal 3,  e.config_file_lineno
+    end
+  end
+
+
+  def tmp_config_file_with(str)
+    file = Tempfile.new('traject_test_config')
+    file.write(str)
+    file.rewind
+
+    return file
+  end
+
+
+end


### PR DESCRIPTION
Okay, here's a go at #99. 

It took a bit more doing then I expected to get it 'right' in terms of reporting good context with errors. Which I think justifies it being here as easily re-usable code. The existing code was un-tested, and didn't produce as good results as it could have in some cases. 

One thing with wrapping the 'real' exception in a Traject::Indexer::ConfigLoadError, is that if you just allow it to rise all the way to the interpreter, the stacktrace you get won't be as useful. (Or if you do anything else that just prints out the actual stacktrace).  I _think_ that's probably out-weighed by the additional useful contextual information we can provide, that you can write code to take advantage of, to give the config-file-writer much better errors in context. 

(Also, I kept going back on whether the class name should be ConfigLoadError or LoadConfigError. Any obvious choice?)