### PR TITLE
When Indexer#process is called with a block, yield the transformed document, allowing #process to be transformed into an enumerable

### DIFF
--- a/lib/traject/indexer.rb
+++ b/lib/traject/indexer.rb
@@ -377,7 +377,8 @@ class Traject::Indexer
 
   # Processes a stream of records, reading from the configured Reader,
   # mapping according to configured mapping rules, and then writing
-  # to configured Writer.
+  # to configured Writer. If a block is provided, the mapped record is also
+  # yielded to that block.
   #
   # returns 'false' as a signal to command line to return non-zero exit code
   # for some reason (reason found in logs, presumably). This particular mechanism
@@ -437,6 +438,7 @@ class Traject::Indexer
         if context.skip?
           log_skip(context)
         else
+          yield context if block_given?
           writer.put context
         end
 

--- a/test/indexer/read_write_test.rb
+++ b/test/indexer/read_write_test.rb
@@ -62,6 +62,11 @@ describe "Traject::Indexer#process" do
     assert writer_settings["memory_writer.closed"]
   end
 
+  it "can be transformed to an Enumerable" do
+    records = @indexer.to_enum(:process, @file).to_a
+    assert_equal 30, records.length
+  end
+
   require 'traject/null_writer'
   it "calls after_processing after processing" do
     @indexer = Traject::Indexer.new(


### PR DESCRIPTION
I'd like to write a wrapper around `Traject#Indexer` that provides `Enumerable` methods, but I'm having trouble figuring out how to do that with just the Writer API. Ideally, I want to work with traject like, e.g.:

```
MyTrajectIndexer.new(io).select { }.reject { }.each do |record|
  # do something
end
```

I wasn't sure if, when a block is provided, it should ignore the writer entirely or not. I decided to just support both, and, for my purposes, make the writer a no-op, but happy to do it the other way instead.
