### PR TITLE
Make extract_marc callable from anywhere?

### DIFF
--- a/lib/traject/macros/marc21.rb
+++ b/lib/traject/macros/marc21.rb
@@ -39,6 +39,9 @@ module Traject::Macros
     #     to_field("title"), extract_marc("245abcd", :trim_punctuation => true)
     #     to_field("id"),    extract_marc("001", :first => true)
     #     to_field("geo"),   extract_marc("040a", :separator => nil, :translation_map => "marc040")
+    #
+    # If you'd like extract_marc functionality but you're not creating an indexer
+    # step, see Traject::Macros::Marc21.extract_marc_from module method. 
     def extract_marc(spec, options = {})
 
       # Raise an error if there are any invalid options, indicating a
@@ -69,6 +72,26 @@ module Traject::Macros
         accumulator.concat extractor.extract(record)
         Marc21.apply_extraction_options(accumulator, options, translation_map)
       end
+    end
+    module_function :extract_marc
+
+    # Convenience method when you want extract_marc behavior, but NOT
+    # to create a lambda for an Indexer step, but instead just give
+    # it a record directly and get back an array of values. 
+    #
+    #     array = Traject::Indexer::Marc21.extract_marc_from(record, "245ab", :trim_punctuation => true)
+    #
+    # If you have a Traject::Indexer::Context and want to pass it in, you can:
+    #
+    #    array = Traject::Indexer::Marc21.extract_marc_from(record, "245ab", :trim_punctuation => true, :context => existing_context)    
+    def self.extract_marc_from(record, spec, options = {})
+      output  = []
+      # Nil context works, but if caller wants to pass one in
+      # for better error reporting that's cool too. 
+      context = options.delete(:context) || nil
+
+      extract_marc(spec, options).call(record, output, context)
+      return output
     end
     
     # Side-effect the accumulator with the options

--- a/test/indexer/macros_marc21_test.rb
+++ b/test/indexer/macros_marc21_test.rb
@@ -118,6 +118,11 @@ describe "Traject::Macros::Marc21" do
     end
   end
 
+  it "supports #extract_marc_from module method" do
+    output_arr = ::Traject::Macros::Marc21.extract_marc_from(@record, "245ab", :trim_punctuation => true)
+    assert_equal ["Manufacturing consent : the political economy of the mass media"], output_arr
+  end
+
   describe "serialized_marc" do
     it "serializes xml" do
       @indexer.instance_eval do


### PR DESCRIPTION
extract_marc is useful enough that sometimes you want to call it from random code, not neccesarily as a traject indexing step. 

This somewhat hackily makes that possible, by elevating certain things to module methods, making possible:

      array = Traject::Indexer::Marc21.extract_marc_from(record, "245ab", :trim_punctuation => true)

This is a somewhat hacky solution -- it might be nice to have a general purpose solution that lets you call _any_ standardly defined traject indexing steps as something other than an indexing step. 

While I have had some clever ideas for doing that, I think they are all a bit _too_ clever, adding too much abstraction and over-complication making traject harder to understand. So I'm resisting them for now. I suggest let's see if we need this one or two more times, and _consider_ abstracting out a common pattern at that point -- or maybe doing this sort of thing as needed is good enough.  Perhaps as the general case, code that you might want to use outside a traject indexing step should just be written as general purpose classes/methods, and then simply used in a traject indexing step. Which is kind of what this does. 