### PR TITLE
Allow accumulator to contain a nil

### DIFF
--- a/lib/traject/indexer.rb
+++ b/lib/traject/indexer.rb
@@ -336,7 +336,7 @@ class Traject::Indexer
       end
 
       if accumulator.size > 0
-        accumulator.compact!
+        # accumulator.compact!
         (context.output_hash[index_step.field_name] ||= []).concat accumulator
       end
 

--- a/lib/traject/macros/marc21.rb
+++ b/lib/traject/macros/marc21.rb
@@ -117,7 +117,7 @@ module Traject::Macros
         accumulator.uniq!
       end
 
-      if default_value && accumulator.empty?
+      if options.has_key?(:default) && accumulator.empty?
         accumulator << default_value
       end
     end

--- a/test/indexer/macros_marc21_test.rb
+++ b/test/indexer/macros_marc21_test.rb
@@ -62,6 +62,14 @@ describe "Traject::Macros::Marc21" do
       assert_equal ["DEFAULT VALUE"], output["only_default"]
     end
 
+    it "allows a nil default" do
+      @indexer.instance_eval do
+        to_field 'default_nil', extract_marc('9999', :default=>nil)
+      end
+      output = @indexer.map_record(@record)
+      assert_equal [nil], output['default_nil']
+    end
+
     it "de-duplicates by default, respects :allow_duplicates" do
       # Add a second 008
       f = @record.fields('008').first


### PR DESCRIPTION
We're currently ignoring 'nil' values (both in logic and by
calling `compact!` on the accumulator), presumably so we
could be sloppy about stuffing stuff into the accumulator.
This breaks the use case (which @jcoyne actually has) where
nil as a value indicates "delete the current value", while
a missing key says "leave the current value alone". He's got
a SPARQL endpoint, but this would be true for things like
ORM models as well and to set a value to NULL in a database
using something like Sequel.

The patch and test allows nil values in the accumulator. Our
tests all run fine, but I'm going to have to do more testing to
see if it breaks anything I currently have in production before
pushing out a release.

I'm asserting that this is how it should work, and we just need to decide if it's a breaking change or not (and, if so, make sure we update our own stuff).