### PR TITLE
Be more forgiving about the record ID field

### DIFF
--- a/test/debug_writer_test.rb
+++ b/test/debug_writer_test.rb
@@ -32,6 +32,47 @@ describe 'Simple output' do
 
   end
 
+  it "deals ok with a missing ID" do
+    context      = Traject::Indexer::Context.new(:output_hash => @indexer.map_record(@record))
+    logger_strio = StringIO.new
+    idfield      = 'id'
+
+    context.logger   = Logger.new(logger_strio)
+    context.position = 1
+
+    context.output_hash.delete(idfield)
+    @writer.put context
+    expected = [
+        "record_num_1 title #{@title}",
+    ]
+    assert_equal expected.join("\n").gsub(/\s/, ''), @io.string.gsub(/\s/, '')
+    assert_match /At least one record \(\#1\) doesn't define field 'id'/, logger_strio.string
+    @writer.close
+
+  end
+
+  it "sets the idfield correctly" do
+    bad_rec_id_field = 'iden'
+    writer           = Traject::DebugWriter.new("output_stream" => @io, "debug_writer.idfield" => bad_rec_id_field)
+
+    context = Traject::Indexer::Context.new(:output_hash => @indexer.map_record(@record))
+
+    logger_strio = StringIO.new
+
+    context.logger   = Logger.new(logger_strio)
+    context.position = 1
+
+    writer.put context
+    expected = [
+        "record_num_1 id #{@id }",
+        "record_num_1 title #{@title}",
+    ]
+    assert_equal expected.join("\n").gsub(/\s/, ''), @io.string.gsub(/\s/, '')
+    assert_match /At least one record \(\#1\) doesn't define field 'iden'/, logger_strio.string
+    writer.close
+
+  end
+
 end
 
 


### PR DESCRIPTION
attn: @jcoyne. This seem like a reasonable way to handle it?

DebugWriter errors out when encountering a record without
an 'id' field (or, more generally, whatever is set in
`debug_writer.idfield`).

New behavior is to emit a warning on first encounter, and use as the record id 
`record_no_N` (where N is the record position).

The warning reads:

```ruby
"At least one record (##{context.position}) doesn't define field '#{@idfield}'.
All records are assumed to have a unique id. You can set which field to look in via the setting 'debug_writer.idfield'"

```

Tests added.
