### PR TITLE
Allow nil values, empty fields, and deduplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,29 @@ after_processing do
 end
 ~~~
 
+## Allowing/disallowing repeating duplicate values
+
+By default, `traject` allows the same value to be added to the same field without
+restriction. You can use the setting `allow_duplicate_values = false` to
+disallow duplicate values (i.e., call `uniq!` on the set of values associated with
+a given field).
+
+## Keeping nil values
+
+`traject` defaults to throwing away any `nil`s that make it into your accumulator
+of values. The setting `allow_nil_values = true` will let `nil` values
+pass through.
+
+# Dealing with  empty fields
+
+Similary, by default `traject` completely ignores empty fields. You can
+change this with the setting `allow_empty_fields = true`, which will result
+in the output hash having a key for every field mentioned in a `to_field`
+statement, whether or not it has any values in it.
+
+Fields that are empty will have a value sent to the writer of an empty
+array (`[]`). Writers that need to special-case empty fields should do so in the
+writer class in question.
 
 ## Readers and Writers
 

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -25,13 +25,60 @@ settings are applied first of all. It's recommended you use `provide`.
 
 ## Known settings
 
+
+### Reading (general)
+
+* `reader_class_name`: a Traject Reader class, used by the indexer as a source of records.   Defaults to Traject::Marc4JReader (using the Java Marc4J library) on JRuby; Traject::MarcReader (using the ruby marc gem) otherwise. Command-line shortcut `-r`
+
+### Threads
+
+* `processing_thread_pool` Number of threads in the main thread pool used for
+   processing records with input rules. On JRuby or Rubinius, defaults to 1 less
+   than the number of processors detected on your machine. On other ruby
+   platforms, defaults to 1.
+
+   **NOTE**: If your processing code isn't thread-safe, set to 0 or nil to
+   disable thread pool and do all processing in main thread.
+
+   Choose a pool size based on size of your machine, and complexity of your
+   indexing rules. You might want to try different sizes and measure which works
+   best for you. Probably no reason for it ever to be more than number of cores
+   on indexing machine.
+
+
+### Writing (general)
+
+* `writer`: An object that implements the Traject Writer interface. If set, takes precedence over `writer_class_name`.
+
+* `writer_class_name`: a Traject Writer class, used by indexer to send processed dictionaries off. Will be used if no explicit `writer` setting or `#writer=` is set. Default Traject::SolrJsonWriter, other writers for debugging or writing to files are also available. See Traject::Indexer for more info. Command line shortcut `-w`
+* `output_file`: Output file to write to for operations that write to files: For instance the `marcout` command, or Writer classes that write to files, like Traject::JsonWriter. Has an shortcut `-o` on command line.
+
+### Writing to solr
+
+* `json_writer.pretty_print`: used by the JsonWriter, if set to true, will output pretty printed json (with added whitespace) for easier human readability. Default false.
+* `solr.url`: URL to connect to a solr instance for indexing, eg http://example.org:8983/solr . Command-line short-cut `-u`.
+
+* `solr.version`: Set to eg "1.4.0", "4.3.0"; currently un-used, but in the future will control some default settings, and/or sanity check and warn you if you're doing something that might not work with that version of solr. Set now for help in the future.
+
+* `solr_writer.batch_size`: size of batches that SolrJsonWriter will send docs to Solr in. Default 100. Set to nil, 0, or 1, and SolrJsonWriter will do one http transaction per document, no batching.
+
+* `solr_writer.commit_on_close`: default false, set to true to have the solr writer send an explicit commit message to Solr after indexing.
+
+* `solr_writer.thread_pool`: defaults to 1 (single bg thread). A thread pool is used for submitting docs to solr. Set to 0 or nil to disable threading. Set to 1, there will still be a single bg thread doing the adds. May make sense to set higher than number of cores on your indexing machine, as these threads will mostly be waiting on Solr. Speed/capacity of your solr might be more relevant. Note that processing_thread_pool threads can end up submitting to solr too, if solr_json_writer.thread_pool is full.
+
+
+### Dealing with MARC data
+
+* `marc_source.type`: default 'binary'. Can also set to 'xml' or (not yet implemented todo) 'json'. Command line shortcut `-t`
+* `marcout.allow_oversized`: Used with `-x marcout` command to output marc when outputting as ISO 2709 binary, set to true or string "true", and the MARC::Writer will have  allow_oversized=true set, allowing oversized records to be serialized with length bytes zero'd out -- technically illegal, but can be read by MARC::Reader in permissive mode.
+
+### Logging and progress
+
 * `debug_ascii_progress`: true/'true' to print ascii characters to STDERR indicating progress. Yes, this is fixed to STDERR, regardless of your logging setup.
   * `.` for every batch of records read and parsed
   * `^` for every batch of records batched and queued for adding to solr (possibly in thread pool)
   * `%` for completing of a Solr 'add'
   * `!` when threadpool for solr add has a full queue, so solr add is going to happen in calling queue -- means solr adding can't keep up with production.
-
-* `json_writer.pretty_print`: used by the JsonWriter, if set to true, will output pretty printed json (with added whitespace) for easier human readability. Default false.
 
 * `log.file`: filename to send logging, or 'STDOUT' or 'STDERR' for those streams. Default STDERR
 
@@ -45,29 +92,9 @@ settings are applied first of all. It's recommended you use `provide`.
 
 * `log.batch_size.severity`: If `log.batch_size` is set, what logger severity level to log to. Default "INFO", set to "DEBUG" etc if desired.
 
-* `marc_source.type`: default 'binary'. Can also set to 'xml' or (not yet implemented todo) 'json'. Command line shortcut `-t`
-
-* `marcout.allow_oversized`: Used with `-x marcout` command to output marc when outputting as ISO 2709 binary, set to true or string "true", and the MARC::Writer will have  allow_oversized=true set, allowing oversized records to be serialized with length bytes zero'd out -- technically illegal, but can be read by MARC::Reader in permissive mode.
-
-* `output_file`: Output file to write to for operations that write to files: For instance the `marcout` command, or Writer classes that write to files, like Traject::JsonWriter. Has an shortcut `-o` on command line.
-
-* `processing_thread_pool` Number of threads in the main thread pool used for processing records with input rules. On JRuby or Rubinius, defaults to 1 less than the number of processors detected on your machine. On other ruby platforms, defaults to 1. Set to 0 or nil to disable thread pool, and do all processing in main thread. 
-
-  Choose a pool size based on size of your machine, and complexity of your indexing rules, you might want to try different sizes and measure which works best for you. Probably no reason for it ever to be more than number of cores on indexing machine.
 
 
-* `reader_class_name`: a Traject Reader class, used by the indexer as a source of records.   Defaults to Traject::Marc4JReader (using the Java Marc4J library) on JRuby; Traject::MarcReader (using the ruby marc gem) otherwise. Command-line shortcut `-r`
 
-* `solr.url`: URL to connect to a solr instance for indexing, eg http://example.org:8983/solr . Command-line short-cut `-u`.
 
-* `solr.version`: Set to eg "1.4.0", "4.3.0"; currently un-used, but in the future will control some default settings, and/or sanity check and warn you if you're doing something that might not work with that version of solr. Set now for help in the future.
 
-* `solr_writer.batch_size`: size of batches that SolrJsonWriter will send docs to Solr in. Default 100. Set to nil, 0, or 1, and SolrJsonWriter will do one http transaction per document, no batching.
 
-* `solr_writer.commit_on_close`: default false, set to true to have the solr writer send an explicit commit message to Solr after indexing.
-
-* `solr_writer.thread_pool`: defaults to 1 (single bg thread). A thread pool is used for submitting docs to solr. Set to 0 or nil to disable threading. Set to 1, there will still be a single bg thread doing the adds. May make sense to set higher than number of cores on your indexing machine, as these threads will mostly be waiting on Solr. Speed/capacity of your solr might be more relevant. Note that processing_thread_pool threads can end up submitting to solr too, if solr_json_writer.thread_pool is full.
-
-* `writer`: An object that implements the Traject Writer interface. If set, takes precedence over `writer_class_name`. 
-
-* `writer_class_name`: a Traject Writer class, used by indexer to send processed dictionaries off. Will be used if no explicit `writer` setting or `#writer=` is set. Default Traject::SolrJsonWriter, other writers for debugging or writing to files are also available. See Traject::Indexer for more info. Command line shortcut `-w`

--- a/lib/traject/indexer.rb
+++ b/lib/traject/indexer.rb
@@ -160,9 +160,10 @@ end
 class Traject::Indexer
 
   # Arity error on a passed block
-  class ArityError < ArgumentError; end
-  class NamingError < ArgumentError; end
-
+  class ArityError < ArgumentError;
+  end
+  class NamingError < ArgumentError;
+  end
 
 
   include Traject::QualifiedConstGet
@@ -179,8 +180,8 @@ class Traject::Indexer
 
   # optional hash or Traject::Indexer::Settings object of settings.
   def initialize(arg_settings = {})
-    @settings = Settings.new(arg_settings)
-    @index_steps = []
+    @settings               = Settings.new(arg_settings)
+    @index_steps            = []
     @after_processing_steps = []
   end
 
@@ -234,7 +235,7 @@ class Traject::Indexer
   def settings(new_settings = nil, &block)
     @settings.merge!(new_settings) if new_settings
 
-    @settings.instance_eval &block if block
+    @settings.instance_eval &block if block_given?
 
     return @settings
   end
@@ -243,12 +244,12 @@ class Traject::Indexer
   # to be called for each record, and generate values for a particular
   # output field.
   def to_field(field_name, aLambda = nil, &block)
-    @index_steps << ToFieldStep.new(field_name, aLambda, block, Traject::Util.extract_caller_location(caller.first) )
+    @index_steps << ToFieldStep.new(field_name, aLambda, block, Traject::Util.extract_caller_location(caller.first))
   end
 
   # Part of DSL, register logic to be called for each record
   def each_record(aLambda = nil, &block)
-    @index_steps << EachRecordStep.new(aLambda, block, Traject::Util.extract_caller_location(caller.first) )
+    @index_steps << EachRecordStep.new(aLambda, block, Traject::Util.extract_caller_location(caller.first))
   end
 
   # Part of DSL, register logic to be called once at the end
@@ -260,16 +261,20 @@ class Traject::Indexer
   def logger
     @logger ||= create_logger
   end
+
   attr_writer :logger
 
 
   def logger_format
     format = settings["log.format"] || "%d %5L %m"
     format = case format
-      when "false" then false
-      when "" then nil
-      else format
-    end
+               when "false" then
+                 false
+               when "" then
+                 nil
+               else
+                 format
+             end
   end
 
   # Create logger according to settings
@@ -278,7 +283,7 @@ class Traject::Indexer
     logger_level  = settings["log.level"] || "info"
 
     # log everything to STDERR or specified logfile
-    logger = Yell::Logger.new(:null)
+    logger        = Yell::Logger.new(:null)
     logger.format = logger_format
     logger.level  = logger_level
 
@@ -287,12 +292,12 @@ class Traject::Indexer
     # on the adapter, so it will stay there if overall level
     # is changed.
     case logger_destination
-    when "STDERR"
-      logger.adapter :stderr, level: logger_level, format: logger_format
-    when "STDOUT"
-      logger.adapter :stdout, level: logger_level, format: logger_format
-    else
-      logger.adapter :file, logger_destination, level: logger_level, format: logger_format
+      when "STDERR"
+        logger.adapter :stderr, level: logger_level, format: logger_format
+      when "STDOUT"
+        logger.adapter :stdout, level: logger_level, format: logger_format
+      else
+        logger.adapter :file, logger_destination, level: logger_level, format: logger_format
     end
 
 
@@ -303,6 +308,7 @@ class Traject::Indexer
 
     return logger
   end
+
 
   # Processes a single record according to indexing rules set up in
   # this indexer. Returns the output hash (a hash whose keys are
@@ -335,21 +341,51 @@ class Traject::Indexer
       # Don't bother if we're skipping this record
       break if context.skip?
 
+      # Set the index step for error reporting
       context.index_step = index_step
-      accumulator = log_mapping_errors(context, index_step) do
+      accumulator        = log_mapping_errors(context, index_step) do
         index_step.execute(context) # will always return [] for an each_record step
       end
 
-      if accumulator.size > 0
-        accumulator.compact!
-        (context.output_hash[index_step.field_name] ||= []).concat accumulator
-      end
+      add_accumulator_to_context!(accumulator, context) if index_step.to_field_step?
 
+      # And unset the index step now that we're finished
       context.index_step = nil
     end
 
     return context
   end
+
+
+  # Add the accumulator to the context with the correct field name
+  # Do post-processing on the accumulator (remove nil values, allow empty
+  # fields, etc)
+  #
+  # Only get here if we've got a to_field step; otherwise the
+  # call to get a field_name will throw an error
+
+  ALLOW_NIL_VALUES       = "allow_nil_values".freeze
+  ALLOW_EMPTY_FIELDS     = "allow_empty_fields".freeze
+  ALLOW_DUPLICATE_VALUES = "allow_duplicate_values".freeze
+
+  def add_accumulator_to_context!(accumulator, context)
+
+    accumulator.compact! unless settings[ALLOW_NIL_VALUES]
+    return if accumulator.empty? and not (settings[ALLOW_EMPTY_FIELDS])
+
+    field_name                      = context.index_step.field_name
+    context.output_hash[field_name] ||= []
+
+    existing_accumulator = context.output_hash[field_name].concat(accumulator)
+    existing_accumulator.uniq! unless settings[ALLOW_DUPLICATE_VALUES]
+
+  rescue NameError => e
+    msg = "Tried to call add_accumulator_to_context with a non-to_field step"
+    msg += context.index_step.inspect
+    logger.error msg
+    raise ArgumentError.new(msg)
+  end
+
 
   # just a wrapper that captures and records any unexpected
   # errors raised in mapping, along with contextual information
@@ -364,7 +400,7 @@ class Traject::Indexer
     begin
       yield
     rescue Exception => e
-      msg =  "Unexpected error on record id `#{context.source_record_id}` at file position #{context.position}\n"
+      msg = "Unexpected error on record id `#{context.source_record_id}` at file position #{context.position}\n"
       msg += "    while executing #{index_step.inspect}\n"
       msg += Traject::Util.exception_to_log_message(e)
 
@@ -392,21 +428,21 @@ class Traject::Indexer
   def process(io_stream)
     settings.fill_in_defaults!
 
-    count      =       0
+    count      = 0
     start_time = batch_start_time = Time.now
     logger.debug "beginning Indexer#process with settings: #{settings.inspect}"
 
     reader = self.reader!(io_stream)
 
     processing_threads = settings["processing_thread_pool"].to_i
-    thread_pool = Traject::ThreadPool.new(processing_threads)
+    thread_pool        = Traject::ThreadPool.new(processing_threads)
 
     logger.info "   Indexer with #{processing_threads} processing threads, reader: #{reader.class.name} and writer: #{writer.class.name}"
 
     log_batch_size = settings["log.batch_size"] && settings["log.batch_size"].to_i
 
-    reader.each do |record; position|
-      count += 1
+    reader.each do |record; position |
+      count    += 1
 
       # have to use a block local var, so the changing `count` one
       # doesn't get caught in the closure. Weird, yeah.
@@ -419,14 +455,14 @@ class Traject::Indexer
       end
 
       context = Context.new(
-        :source_record => record,
-        :settings => settings,
-        :position => position,
-        :logger => logger
+          :source_record => record,
+          :settings      => settings,
+          :position      => position,
+          :logger        => logger
       )
 
       if log_batch_size && (count % log_batch_size == 0)
-        batch_rps = log_batch_size / (Time.now - batch_start_time)
+        batch_rps   = log_batch_size / (Time.now - batch_start_time)
         overall_rps = count / (Time.now - start_time)
         logger.send(settings["log.batch_size.severity"].downcase.to_sym, "Traject::Indexer#process, read #{count} records at id:#{context.source_record_id}; #{'%.0f' % batch_rps}/s this batch, #{'%.0f' % overall_rps}/s overall")
         batch_start_time = Time.now
@@ -466,8 +502,8 @@ class Traject::Indexer
       end
     end
 
-    elapsed        = Time.now - start_time
-    avg_rps        = (count / elapsed)
+    elapsed = Time.now - start_time
+    avg_rps = (count / elapsed)
     logger.info "finished Indexer#process: #{count} records in #{'%.3f' % elapsed} seconds; #{'%.1f' % avg_rps} records/second overall."
 
     if writer.respond_to?(:skipped_record_count) && writer.skipped_record_count > 0
@@ -533,17 +569,17 @@ class Traject::Indexer
     # We'd have #cause in ruby 2.1, filled out for us, but we want
     # to work before then, so we use our own 'original'
     attr_reader :original, :config_file, :config_file_lineno, :config_file_backtrace
+
     def initialize(config_file_path, original_exception)
-      @original               = original_exception
-      @config_file            = config_file_path
-      @config_file_lineno     = Traject::Util.backtrace_lineno_for_config(config_file_path, original_exception)
-      @config_file_backtrace  = Traject::Util.backtrace_from_config(config_file_path, original_exception)
-      message = "Error loading configuration file #{self.config_file}:#{self.config_file_lineno} #{original_exception.class}:#{original_exception.message}"
+      @original              = original_exception
+      @config_file           = config_file_path
+      @config_file_lineno    = Traject::Util.backtrace_lineno_for_config(config_file_path, original_exception)
+      @config_file_backtrace = Traject::Util.backtrace_from_config(config_file_path, original_exception)
+      message                = "Error loading configuration file #{self.config_file}:#{self.config_file_lineno} #{original_exception.class}:#{original_exception.message}"
 
       super(message)
     end
   end
-
 
 
 end

--- a/lib/traject/indexer/settings.rb
+++ b/lib/traject/indexer/settings.rb
@@ -57,35 +57,46 @@ class Traject::Indexer
     def fill_in_defaults!
       self.reverse_merge!(self.class.defaults)
     end
-    
-    
+
+
     def self.mri_defaults
       {
-        "reader_class_name"         => "Traject::MarcReader",
-        "writer_class_name"         => "Traject::SolrJsonWriter",
-        "marc_source.type"          => "binary",            
-        "solrj_writer.batch_size"   => 200,
-        "solrj_writer.thread_pool"  => 1,
-        "processing_thread_pool"    => self.default_processing_thread_pool,
-        "log.batch_size.severity"   => "info"
+          # Reader defaults
+          "reader_class_name"       => "Traject::MarcReader",
+          "marc_source.type"        => "binary",
+
+          # Writer defaults
+          "writer_class_name"       => "Traject::SolrJsonWriter",
+          "solr_writer.batch_size"  => 100,
+          "solr_writer.thread_pool" => 1,
+
+          # Threading and logging
+          "processing_thread_pool"  => self.default_processing_thread_pool,
+          "log.batch_size.severity" => "info",
+
+          # how to post-process the accumulator
+          "allow_nil_values"        => false,
+          "allow_duplicate_values"  => true,
+
+          "allow_empty_fields"      => false,
       }
     end
 
     def self.jruby_defaults
       {
-        'reader_class_name' => "Traject::Marc4JReader",
-        'marc4j_reader.permissive' => true
+          'reader_class_name'        => "Traject::Marc4JReader",
+          'marc4j_reader.permissive' => true
       }
     end
-    
-        
+
+
     def self.defaults
       return @@defaults if defined? @@defaults
       default_settings = self.mri_defaults
       if defined? JRUBY_VERSION
         default_settings.merge! self.jruby_defaults
       end
-      
+
       @@defaults = default_settings
     end
 

--- a/lib/traject/indexer/step.rb
+++ b/lib/traject/indexer/step.rb
@@ -22,6 +22,11 @@ class Traject::Indexer
       self.validate!
     end
 
+    def to_field_step?
+      false
+    end
+
+
     # Set the arity of the lambda expression just once, when we define it
     def lambda=(lam)
       @lambda_arity = 0 # assume
@@ -99,6 +104,10 @@ class Traject::Indexer
       validate!
     end
 
+    def to_field_step?
+      true
+    end
+
     def lambda=(lam)
       @lambda       = lam
       @lambda_arity = @lambda ? @lambda.arity : 0
@@ -155,6 +164,11 @@ class Traject::Indexer
       self.lambda          = lambda
       self.block           = block
       self.source_location = source_location
+    end
+
+
+    def to_field_step?
+      false
     end
 
     # after_processing steps get no args yielded to

--- a/lib/traject/macros/marc21.rb
+++ b/lib/traject/macros/marc21.rb
@@ -117,7 +117,7 @@ module Traject::Macros
         accumulator.uniq!
       end
 
-      if default_value && accumulator.empty?
+      if options.has_key?(:default) && accumulator.empty?
         accumulator << default_value
       end
     end

--- a/test/indexer/macros_marc21_test.rb
+++ b/test/indexer/macros_marc21_test.rb
@@ -14,7 +14,7 @@ describe "Traject::Macros::Marc21" do
 
   before do
     @indexer = Traject::Indexer.new
-    @record = MARC::Reader.new(support_file_path  "manufacturing_consent.marc").to_a.first
+    @record  = MARC::Reader.new(support_file_path "manufacturing_consent.marc").to_a.first
   end
 
   describe "extract_marc" do
@@ -27,7 +27,7 @@ describe "Traject::Macros::Marc21" do
 
       assert_equal ["Manufacturing consent : the political economy of the mass media /"], output["title"]
       assert_equal({}, @indexer.map_record(empty_record))
-      
+
     end
 
     it "respects :first=>true option" do
@@ -38,7 +38,7 @@ describe "Traject::Macros::Marc21" do
       output = @indexer.map_record(@record)
 
       assert_length 1, output["other_id"]
-      
+
     end
 
     it "trims punctuation with :trim_punctuation => true" do
@@ -50,7 +50,7 @@ describe "Traject::Macros::Marc21" do
 
       assert_equal ["Manufacturing consent : the political economy of the mass media"], output["title"]
       assert_equal({}, @indexer.map_record(empty_record))
-      
+
     end
 
     it "respects :default option" do
@@ -69,7 +69,7 @@ describe "Traject::Macros::Marc21" do
 
       @indexer.instance_eval do
         to_field "lang1", extract_marc('008[35-37]')
-        to_field "lang2", extract_marc('008[35-37]', :allow_duplicates=>true)
+        to_field "lang2", extract_marc('008[35-37]', :allow_duplicates => true)
       end
 
       output = @indexer.map_record(@record)
@@ -87,6 +87,26 @@ describe "Traject::Macros::Marc21" do
     end
 
 
+    it "throws away nil values unless settings['allow_nil_values]'" do
+      @indexer.instance_eval do
+        to_field 'default_nil', extract_marc('9999', :default => nil)
+      end
+      output = @indexer.map_record(@record)
+      assert_nil output['default_nil']
+    end
+
+    
+
+    it "allows nil values if settings['allow_nil_values]'" do
+      @indexer.settings do |s|
+        s['allow_nil_values'] = true
+      end
+      @indexer.instance_eval do
+        to_field 'default_nil', extract_marc('9999', :default => nil)
+      end
+      output = @indexer.map_record(@record)
+      assert_equal [nil], output['default_nil']
+    end
 
 
     it "Marc21::trim_punctuation class method" do
@@ -145,7 +165,7 @@ describe "Traject::Macros::Marc21" do
       assert_length 1, output["marc_record"]
       assert_kind_of String, output["marc_record"].first
 
-      decoded = Base64.decode64( output["marc_record"].first )
+      decoded = Base64.decode64(output["marc_record"].first)
 
       # just check the marc header for now
       assert_start_with "02067cam a2200469", decoded
@@ -174,7 +194,7 @@ describe "Traject::Macros::Marc21" do
 
       # okay, let's actually deserialize it, why not
 
-      hash = JSON.parse( output["marc_record"].first )
+      hash = JSON.parse(output["marc_record"].first)
 
       deserialized = MARC::Record.new_from_hash(hash)
 

--- a/test/indexer/read_write_test.rb
+++ b/test/indexer/read_write_test.rb
@@ -5,7 +5,11 @@ require 'test_helper'
 memory_writer_class = Class.new do
     def initialize(settings)
       # store them in a class variable so we can test em later
+      # Supress the warning message
+      original_verbose, $VERBOSE = $VERBOSE, nil
       @@last_writer_settings = @settings = settings
+      # Activate warning messages again.
+      $VERBOSE = original_verbose
       @settings["memory_writer.added"] = []
     end
 


### PR DESCRIPTION
This adds three new settings (all of whose defaults reflect current behavior)

* `allow_nil_values` (default: false). Allow nil values to be sent on to the writer
* `allow_duplicate_values` (default: true). Allow duplicate values. Set to false to
  force only unique values.
* `allow_empty_fields` (default: false). Default behavior is that the output hash
  doesn't even contain keys for a `to_field` which doesn't produce any values.
  Set to `true` to pass empty fields on (with the value being an empty array)

Tests have been added for all the new behavior.

Updated the README and settings.md, and reorganized the latter as well.