### PR TITLE
bugfix to regexp in specification parsing

### DIFF
--- a/lib/traject/macros/marc21.rb
+++ b/lib/traject/macros/marc21.rb
@@ -238,6 +238,10 @@ module Traject::Macros
       # single square bracket characters if they are the start and/or end
       #   chars and there are no internal square brackets.
       str = str.sub(/\A\[?([^\[\]]+)\]?\Z/, '\1')
+
+      # trim any leading or trailing whitespace
+      str.strip!
+
       return str
     end
 

--- a/lib/traject/marc_extractor_spec.rb
+++ b/lib/traject/marc_extractor_spec.rb
@@ -170,7 +170,7 @@ module Traject
         hash         = Hash.new
 
         # Split the string(s) given on colon
-        spec_strings = spec_string.is_a?(Array) ? spec_string.map { |s| s.split(/\s*:\s*/) }.flatten : spec_string.split(/s*:\s*/)
+        spec_strings = spec_string.is_a?(Array) ? spec_string.map { |s| s.split(/\s*:\s*/) }.flatten : spec_string.split(/\s*:\s*/)
 
         spec_strings.each do |part|
           if m = DATAFIELD_PATTERN.match(part)

--- a/test/indexer/macros_marc21_test.rb
+++ b/test/indexer/macros_marc21_test.rb
@@ -118,6 +118,8 @@ describe "Traject::Macros::Marc21" do
       assert_equal "one two three", Marc21.trim_punctuation("one two three:")
       assert_equal "one two three .", Marc21.trim_punctuation("one two three .")
       assert_equal "one two three", Marc21.trim_punctuation("one two three.")
+      assert_equal "one two three...", Marc21.trim_punctuation("one two three...")
+      assert_equal "one two three", Marc21.trim_punctuation(" one two three")
 
       assert_equal "one two [three]", Marc21.trim_punctuation("one two [three]")
       assert_equal "one two three", Marc21.trim_punctuation("one two three]")

--- a/test/marc_extractor_test.rb
+++ b/test/marc_extractor_test.rb
@@ -35,7 +35,7 @@ describe "Traject::MarcExtractor" do
     end
 
     it "parses a mixed bag" do
-      parsed  = Traject::MarcExtractor::Spec.hash_from_string("245abcde:810:700|*4|bcd")
+      parsed  = Traject::MarcExtractor::Spec.hash_from_string("245abcdes:810:700|*4|bcd")
       spec245 = parsed['245'].first
       spec810 = parsed['810'].first
       spec700 = parsed['700'].first
@@ -46,7 +46,7 @@ describe "Traject::MarcExtractor" do
       assert spec245
       assert_nil spec245.indicator1
       assert_nil spec245.indicator2
-      assert_equal %w{a b c d e}, spec245.subfields
+      assert_equal %w{a b c d e s}, spec245.subfields
 
       #810
       assert spec810


### PR DESCRIPTION
Besides fixing the regexp (s to \s), I added an "s" subfield to the existing spec parsing test.