### PR TITLE
Change trim_punctuation to strip period from unicode strings. #133.

### DIFF
--- a/lib/traject/macros/marc21.rb
+++ b/lib/traject/macros/marc21.rb
@@ -233,7 +233,7 @@ module Traject::Macros
       str = str.sub(/ *[ ,\/;:] *\Z/, '')
 
       # trailing period if it is preceded by at least three letters (possibly preceded and followed by whitespace)
-      str = str.sub(/( *\w\w\w)\. *\Z/, '\1')
+      str = str.sub(/( *[[:word:][:word:][:word:]])\. *\Z/, '\1')
 
       # single square bracket characters if they are the start and/or end
       #   chars and there are no internal square brackets.

--- a/test/indexer/macros_marc21_test.rb
+++ b/test/indexer/macros_marc21_test.rb
@@ -128,6 +128,8 @@ describe "Traject::Macros::Marc21" do
 
       # This one was a bug before
       assert_equal "Feminism and art", Marc21.trim_punctuation("Feminism and art.")
+
+      assert_equal "Le réve", Marc21.trim_punctuation("Le réve.") # this assertion currently fails
     end
 
     it "uses :translation_map" do


### PR DESCRIPTION
This addresses the problem in Issue #133 where punctuation wasn't being stripped from a non-ASCII string. I only addressed the period stripping, not the rest of trim_punctuation.