### PR TITLE
Allow users to pass procedures to to_field.

### DIFF
--- a/lib/traject/indexer.rb
+++ b/lib/traject/indexer.rb
@@ -242,7 +242,10 @@ class Traject::Indexer
   # Part of DSL, used to define an indexing mapping. Register logic
   # to be called for each record, and generate values for a particular
   # output field.
-  def to_field(field_name, aLambda = nil, &block)
+  def to_field(field_name, aLambda = nil, block = Proc.new { |*args| })
+    if block_given?
+      block = Proc.new { |*args| yield args }
+    end
     @index_steps << ToFieldStep.new(field_name, aLambda, block, Traject::Util.extract_caller_location(caller.first))
   end
 


### PR DESCRIPTION
The current implementation of `Traject::Indexer#to_field` forces the user
to use an explicit block by specifying `&block` in the method
signature.

Because blocks are syntactical sugar (not objects), it is difficult for
a user to test the code in the block independently from the to_field
method.

This commit fixes this problem by changing the signature so that it
accepts a Proc instead of a block.  In the cases where a block is
passed, the block is coerced into a Proc without the use of &. This
allows the user of `to_field` to implement any custom `block` code
either as a ruby block or a Proc.

For your consideration:

```ruby
def block_or_proc(block = Proc.new {|*args|})
  if block_given?
    block = Proc.new { |*args| yield args }
  end

  block
end

a = block_or_proc { puts "hello" }
a.call

p = Proc.new { puts "goodbye "}
b = block_or_proc(p)
b.call

p = Proc.new { |x, y, z| x + y }
c = block_or_proc(p)
c = c.call(3, 4)
puts c

d = block_or_proc { |x, y, z| x + y + z }
d = d.call(3, 4, 1)
puts d

e = block_or_proc
puts e.call
```