### PR TITLE
Move add_accumulator_to_context to ToFieldStep

### DIFF
--- a/lib/traject/indexer/step.rb
+++ b/lib/traject/indexer/step.rb
@@ -150,9 +150,26 @@ class Traject::Indexer
       end
 
 
+      add_accumulator_to_context!(accumulator, context)
       return accumulator
     end
 
+    # Add the accumulator to the context with the correct field name
+    # Do post-processing on the accumulator (remove nil values, allow empty
+    # fields, etc)
+    ALLOW_NIL_VALUES       = "allow_nil_values".freeze
+    ALLOW_EMPTY_FIELDS     = "allow_empty_fields".freeze
+    ALLOW_DUPLICATE_VALUES = "allow_duplicate_values".freeze
+
+    def add_accumulator_to_context!(accumulator, context)
+      accumulator.compact! unless context.settings[ALLOW_NIL_VALUES]
+      return if accumulator.empty? and not (context.settings[ALLOW_EMPTY_FIELDS])
+
+      context.output_hash[field_name] ||= []
+
+      existing_accumulator = context.output_hash[field_name].concat(accumulator)
+      existing_accumulator.uniq! unless context.settings[ALLOW_DUPLICATE_VALUES]
+    end
   end
 
 # A class representing a block of logic called after


### PR DESCRIPTION
I'm thinking this may be an easy way to open up traject to support things like:

https://github.com/billdueber/indexing_thoughts/blob/master/old_readme.md#thought-1-pass-around-capsules

and allow me to extend traject in my local application to support things like single-valued fields.