### PR TITLE
eliminate some 'warning: instance variable X not initialized' warnings

### DIFF
--- a/lib/traject/debug_writer.rb
+++ b/lib/traject/debug_writer.rb
@@ -40,12 +40,9 @@ class Traject::DebugWriter < Traject::LineWriter
     @idfield = settings["debug_writer.idfield"] || DEFAULT_IDFIELD
     @format  = settings['debug_writer.format'] || DEFAULT_FORMAT
 
-    if @idfield == 'record_position' then
-      @use_position = true
-    end
+    @use_position = (@idfield == 'record_position')
 
     @already_threw_warning_about_missing_id = false
-
   end
 
   def record_number(context)

--- a/lib/traject/marc_extractor.rb
+++ b/lib/traject/marc_extractor.rb
@@ -151,6 +151,8 @@ module Traject
       if options[:alternate_script] != false
         @fetch_alternate_script = true
         show_interest_in_tag(ALTERNATE_SCRIPT_TAG)
+      else
+        @fetch_alternate_script = false
       end
 
       @interesting_tags_list = @interesting_tags_hash.keys


### PR DESCRIPTION
warning when running ruby with '-w`, which the test suite maybe does or maybe it's just my machine