### PR TITLE
For 3.0: standard transformation procs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,30 @@
 
       to_field ["field1", "field2"], extract_marc("240")
 
+* `to_field` can take multiple transformation procs (all with the same form). https://github.com/traject/traject/pull/153
+
+* Existing arguments to `marc_extract` have been provided as transformation proc macros, along with some additional new useful general purposes transformations, in [Traject::Macros::Transformations](./lib/traject/macros/transformation.rb). https://github.com/traject/traject/pull/154
+
+  This is the new preferred way to do post-processing with the `marc_extract` options, but the existing options are not deprecated and there is no current plan for them to be removed.
+  * before:
+
+        to_field "some_field", extract_marc("800",
+                                translation_map: "marc_800_map",
+                                allow_duplicates: true,
+                                first: true,
+                                default: "default value")
+  * now preferred:
+
+        to_field "some_field", extract_marc("800", allow_duplicates: true),
+            translation_map("marc_800_map"),
+            first_only,
+            default("default value")
+
+    (still need `allow_duplicates: true` cause extract_marc defaults to false, but see also `unique` macro)
+
+  * So, these transformation steps can now be used with non-MARC formats as well. See also `strip`, `split`, `append`, `prepend`, and `gsub`.
+
+
 
 ## 2.3.4
   * Totally internal change to provide easier hooks into indexing process

--- a/lib/traject/indexer.rb
+++ b/lib/traject/indexer.rb
@@ -15,6 +15,7 @@ require 'traject/debug_writer'
 
 require 'traject/macros/marc21'
 require 'traject/macros/basic'
+require 'traject/macros/transformation'
 
 if defined? JRUBY_VERSION
   require 'traject/marc4j_reader'
@@ -175,6 +176,7 @@ class Traject::Indexer
   # default macro modules provided)
   include Traject::Macros::Marc21
   include Traject::Macros::Basic
+  include Traject::Macros::Transformation
 
 
   # optional hash or Traject::Indexer::Settings object of settings.

--- a/lib/traject/macros/marc21.rb
+++ b/lib/traject/macros/marc21.rb
@@ -122,6 +122,14 @@ module Traject::Macros
       end
     end
 
+    # A transformation macro version of trim_punctuation -- heuristics for trimming punctuation
+    # from AACR2/MARC style values, to get bare values.
+    def trim_punctuation
+      lambda do |rec, accumulator|
+        accumulator.collect! {|s| Marc21.trim_punctuation(s)}
+      end
+    end
+
 
     #  A list of symbols that are valid keys in the options hash
     EXTRACT_MARC_VALID_OPTIONS = [:first, :trim_punctuation, :default,

--- a/lib/traject/macros/transformation.rb
+++ b/lib/traject/macros/transformation.rb
@@ -43,7 +43,7 @@ module Traject
         lambda do |rec, acc|
           acc.collect! do |v|
             # unicode whitespace class aware
-            v.gsub(/\A[[:space:]]+|[[:space:]]+\Z/, '')
+            v.sub(/\A[[:space:]]+/,'').sub(/[[:space:]]+\Z/, '')
           end
         end
       end

--- a/lib/traject/macros/transformation.rb
+++ b/lib/traject/macros/transformation.rb
@@ -1,0 +1,77 @@
+module Traject
+  module Macros
+    # Macros intended to be mixed into an Indexer and used in config
+    # as second or further args to #to_field, to transform existing accumulator values.
+    #
+    # They have the same form as any proc/block passed to #to_field, but
+    # operate on an existing accumulator, intended to be used as non-first-step
+    # transformations.
+    #
+    # Some of these are extracted from extract_marc options, so they can be
+    # used with any first-step extract methods.  Some informed by current users.
+    module Transformation
+
+      def translation_map(translation_map_specifier)
+        translation_map = Traject::TranslationMap.new(translation_map_specifier)
+
+        lambda do |rec, acc|
+          translation_map.translate_array! acc
+        end
+      end
+
+      def default(default_value)
+        lambda do |rec, acc|
+          if acc.empty?
+            acc << default_value
+          end
+        end
+      end
+
+      def first_only
+        lambda do |rec, acc|
+          acc.replace Array(acc[0])
+        end
+      end
+
+      def unique
+        lambda do |rec, acc|
+          acc.uniq!
+        end
+      end
+
+      def strip
+        lambda do |rec, acc|
+          acc.collect! do |v|
+            # unicode whitespace class aware
+            v.gsub(/\A[[:space:]]+|[[:space:]]+\Z/, '')
+          end
+        end
+      end
+
+      def split(separator)
+        lambda do |rec, acc|
+          acc.replace( acc.flat_map { |v| v.split(separator) } )
+        end
+      end
+
+      def append(suffix)
+        lambda do |rec, acc|
+          acc.collect! { |v| v + suffix }
+        end
+      end
+
+      def prepend(prefix)
+        lambda do |rec, acc|
+          acc.collect! { |v| prefix + v }
+        end
+      end
+
+      def gsub(pattern, replace)
+        lambda do |rec, acc|
+          acc.collect! { |v| v.gsub(pattern, replace) }
+        end
+      end
+
+    end
+  end
+end

--- a/lib/traject/solr_json_writer.rb
+++ b/lib/traject/solr_json_writer.rb
@@ -257,7 +257,7 @@ class Traject::SolrJsonWriter
 
     # First, try the /update/json handler
     candidate = [url.chomp('/'), 'update', 'json'].join('/')
-    resp      = @http_client.get(candidate)
+    resp      = @http_client.get(candidate, {"commit" => 'true'})
     if resp.status == 404
       candidate = [url.chomp('/'), 'update'].join('/')
     end

--- a/test/indexer/macros/marc21/extract_marc_test.rb
+++ b/test/indexer/macros/marc21/extract_marc_test.rb
@@ -48,7 +48,17 @@ describe "extract_marc" do
 
     assert_equal ["Manufacturing consent : the political economy of the mass media"], output["title"]
     assert_equal({}, @indexer.map_record(empty_record))
+  end
 
+  it "can use trim_punctuation as transformation macro" do
+    @indexer.instance_eval do
+      to_field "title", extract_marc("245ab"), trim_punctuation
+    end
+
+    output = @indexer.map_record(@record)
+
+    assert_equal ["Manufacturing consent : the political economy of the mass media"], output["title"]
+    assert_equal({}, @indexer.map_record(empty_record))
   end
 
   it "respects :default option" do

--- a/test/indexer/macros/transformation_test.rb
+++ b/test/indexer/macros/transformation_test.rb
@@ -52,7 +52,7 @@ describe "Traject::Macros::Transformation" do
         to_field "test", first_only
       end
       output = @indexer.map_record(@record)
-      assert_equal nil, output["test"]
+      assert_nil output["test"]
     end
 
     it "no-ops on single value" do

--- a/test/indexer/macros/transformation_test.rb
+++ b/test/indexer/macros/transformation_test.rb
@@ -1,0 +1,135 @@
+# Encoding: UTF-8
+
+require 'test_helper'
+require 'traject/indexer'
+
+# should be built into every indexer
+describe "Traject::Macros::Transformation" do
+  before do
+    @indexer = Traject::Indexer.new
+    @record = nil
+  end
+
+  describe "translation_map" do
+    it "translates" do
+      @indexer.instance_eval do
+        to_field "cataloging_agency", literal("DLC"), translation_map("marc_040a_translate_test")
+      end
+      output = @indexer.map_record(@record)
+      assert_equal ["Library of Congress"], output["cataloging_agency"]
+    end
+  end
+
+  describe "default" do
+    it "adds default to empty accumulator" do
+      @indexer.instance_eval do
+        to_field "test", default("default")
+      end
+      output = @indexer.map_record(@record)
+      assert_equal ["default"], output["test"]
+    end
+
+    it "does not add default if value present" do
+      @indexer.instance_eval do
+        to_field "test", literal("value"), default("defaut")
+      end
+      output = @indexer.map_record(@record)
+      assert_equal ["value"], output["test"]
+    end
+  end
+
+  describe "first_only" do
+    it "takes only first in multi-value" do
+      @indexer.instance_eval do
+        to_field "test", literal("one"), literal("two"), literal("three"), first_only
+      end
+      output = @indexer.map_record(@record)
+      assert_equal ["one"], output["test"]
+    end
+
+    it "no-ops on nil" do
+      @indexer.instance_eval do
+        to_field "test", first_only
+      end
+      output = @indexer.map_record(@record)
+      assert_equal nil, output["test"]
+    end
+
+    it "no-ops on single value" do
+      @indexer.instance_eval do
+        to_field "test", literal("one"), first_only
+      end
+      output = @indexer.map_record(@record)
+      assert_equal ["one"], output["test"]
+    end
+  end
+
+  describe "unique" do
+    it "uniqs" do
+      @indexer.instance_eval do
+        to_field "test", literal("one"), literal("two"), literal("one"), literal("three"), unique
+      end
+      output = @indexer.map_record(@record)
+      assert_equal ["one", "two", "three"], output["test"]
+    end
+  end
+
+  describe "strip" do
+    it "strips" do
+      @indexer.instance_eval do
+        to_field "test", literal("  one"), literal(" two  "), strip
+      end
+      output = @indexer.map_record(@record)
+      assert_equal ["one", "two"], output["test"]
+    end
+
+    it "strips unicode whitespace" do
+      @indexer.instance_eval do
+        to_field "test", literal(" \u00A0 \u2002 one \u202F "), strip
+      end
+      output = @indexer.map_record(@record)
+      assert_equal ["one"], output["test"]
+    end
+  end
+
+  describe "split" do
+    it "splits" do
+      @indexer.instance_eval do
+        to_field "test", literal("one.two"), split(".")
+      end
+      output = @indexer.map_record(@record)
+      assert_equal ["one", "two"], output["test"]
+    end
+  end
+
+  describe "append" do
+    it "appends suffix" do
+      @indexer.instance_eval do
+        to_field "test", literal("one"), literal("two"), append(".suffix")
+      end
+      output = @indexer.map_record(@record)
+      assert_equal ["one.suffix", "two.suffix"], output["test"]
+    end
+  end
+
+  describe "prepend" do
+    it "prepends prefix" do
+      @indexer.instance_eval do
+        to_field "test", literal("one"), literal("two"), prepend("prefix.")
+      end
+      output = @indexer.map_record(@record)
+      assert_equal ["prefix.one", "prefix.two"], output["test"]
+    end
+  end
+
+  describe "gsub" do
+    it "gsubs" do
+      @indexer.instance_eval do
+        to_field "test", literal("one1212two23three"), gsub(/\d+/, ' ')
+      end
+      output = @indexer.map_record(@record)
+      assert_equal ["one two three"], output["test"]
+    end
+  end
+
+end


### PR DESCRIPTION
@billdueber the next step to #153 for 3.0 release
 
Some of these transformation procs were extracted from `extract_marc`, others from demonstrated use cases in stanford's [traject_plus](https://github.com/sul-dlss/traject_plus/blob/59b9b8fc59aaeae2093847bfc02ecf015f867892/lib/traject_plus/macros.rb). 

`trim_punctuation` isn't here, because I think that strip algorithm is really AACR2/MARC-specific and needed mostly in MARC use cases.  But we could still pull it out into a transformation proc in the Marc module. Or maybe I'm wrong and it is general purpose. thoughts?