### PR TITLE
Eliminate Solr missing content stream error

### DIFF
--- a/lib/traject/solr_json_writer.rb
+++ b/lib/traject/solr_json_writer.rb
@@ -255,7 +255,7 @@ class Traject::SolrJsonWriter
 
     # First, try the /update/json handler
     candidate = [url.chomp('/'), 'update', 'json'].join('/')
-    resp      = @http_client.get(candidate)
+    resp      = @http_client.get(candidate, {"commit" => 'true'})
     if resp.status == 404
       candidate = [url.chomp('/'), 'update'].join('/')
     end


### PR DESCRIPTION
Solr 5.5 and Solr 6.6 report an error if there is no payload
  org.apache.solr.common.SolrException: missing content stream