### PR TITLE
Add continue_after_exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,15 @@ Fields that are empty will have a value sent to the writer of an empty
 array (`[]`). Writers that need to special-case empty fields should do so in the
 writer class in question.
 
+### Error Handling
+
+The default behavior is to terminate processing when an otherwise-unhandled
+("unexpected") exception occurs during processing.  This usually indicates a bug in the code that handles transformations, but there are situations where this behavior may not fit your needs.
+
+After carefully considering the implications, you have the option of changing
+the `continue_after_exception` setting to
+`true`, which will cause traject to log the exception and continue. 
+
 ## The traject command Line
 
 The simplest invocation is:

--- a/lib/traject/indexer.rb
+++ b/lib/traject/indexer.rb
@@ -376,8 +376,8 @@ class Traject::Indexer
       rescue Exception => marc_to_s_exception
         logger.debug "(Could not log record, #{marc_to_s_exception})"
       end
+      raise e unless @settings['continue_after_exception']
 
-      raise e
     end
   end
 
@@ -406,7 +406,7 @@ class Traject::Indexer
 
     log_batch_size = settings["log.batch_size"] && settings["log.batch_size"].to_i
 
-    reader.each do |record; position |
+    reader.each do |record; position|
       count    += 1
 
       # have to use a block local var, so the changing `count` one
@@ -443,9 +443,7 @@ class Traject::Indexer
         else
           writer.put context
         end
-
       end
-
     end
     $stderr.write "\n" if settings["debug_ascii_progress"].to_s == "true"
 

--- a/lib/traject/indexer/settings.rb
+++ b/lib/traject/indexer/settings.rb
@@ -79,6 +79,7 @@ class Traject::Indexer
           "allow_duplicate_values"  => true,
 
           "allow_empty_fields"      => false,
+          "continue_after_exception" => false,
       }
     end
 

--- a/lib/traject/version.rb
+++ b/lib/traject/version.rb
@@ -1,3 +1,3 @@
 module Traject
-  VERSION = "2.3.4"
+  VERSION = '2.3.5'.freeze
 end


### PR DESCRIPTION
I'm not convinced this is a great idea, but ...

Sometimes you have a problematic record or two in a large batch and you might not want the whole job to terminate when you encounter an unexpected exception.  This adds a `continue_after_exception` setting (which defaults to `false`) that continues even if such an exception occurs.