### PR TITLE
perhaps travis sudo:true will get it magically downloading jruby succesfully again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 cache: bundler
-sudo: false
+sudo: true
 rvm:
   - jruby-9.0.5.0
   - jruby-9.1.15.0


### PR DESCRIPTION
https://github.com/jruby/jruby/wiki/FAQs#why-is-jruby-so-slow-to-install-why-does-jruby-take-so-long-to-make-secure-connections
https://github.com/travis-ci/travis-ci/issues/6619