### PR TITLE
Traject::Indexer#configure is available and recommended instead of direct #instance_eval

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,8 @@
 
 * Placeholder
 
+* Traject::Indexer#configure is available, and recommended instead of raw `instance_eval`. It just does an instance_eval, but is clearer and safer for future changes.
+
 * `to_field` can now take an array as a first argument, to send values to multiple fields mentioned, eg:
 
       to_field ["field1", "field2"], extract_marc("240")

--- a/doc/programmatic_use.md
+++ b/doc/programmatic_use.md
@@ -24,10 +24,10 @@ indexer.load_config_file(path_to_config)
 
 This can be convenient for config files you can use either from the command line, or programmatically. Or for allowing other staff roles to write config files separately. You can call `load_config_file` multiple times, and order may matter -- exactly the same as command line configuration files.
 
-Alternately, you may instead want to do your configuration inline, using instance_eval:
+Alternately, you may instead want to do your configuration inline, using `configure` (which just does an `instance_eval`, but is encourage for clarity and forwards-compatibility:
 
 ```ruby
-indexer.instance_eval do
+indexer.configure do
   # you can choose to load config files this way
   load_config_file(path_to_config)
 

--- a/lib/traject/indexer.rb
+++ b/lib/traject/indexer.rb
@@ -184,6 +184,13 @@ class Traject::Indexer
     instance_eval(&block) if block
   end
 
+  # Right now just does an `instance_eval`, but encouraged in case we change the underlying
+  # implementation later, and to make intent more clear.
+  def configure(&block)
+    instance_eval(&block)
+  end
+
+
   # Pass a string file path, a Pathname, or a File object, for
   # a config file to load into indexer.
   #

--- a/test/debug_writer_test.rb
+++ b/test/debug_writer_test.rb
@@ -9,7 +9,7 @@ describe 'Simple output' do
   before do
     @record = MARC::Reader.new(support_file_path  "manufacturing_consent.marc").to_a.first
     @indexer = Traject::Indexer.new
-    @indexer.instance_eval do
+    @indexer.configure do
       to_field "id", extract_marc("001", :first => true)
       to_field "title", extract_marc("245ab")
     end

--- a/test/indexer/macros/marc21/extract_all_marc_values_test.rb
+++ b/test/indexer/macros/marc21/extract_all_marc_values_test.rb
@@ -31,7 +31,7 @@ describe "The extract_all_marc_values macro" do
   end
 
   it "#extract_all_marc_values" do
-    @indexer.instance_eval do
+    @indexer.configure do
       to_field "text", extract_all_marc_values
     end
     output = @indexer.map_record(@record)

--- a/test/indexer/macros/marc21/extract_marc_test.rb
+++ b/test/indexer/macros/marc21/extract_marc_test.rb
@@ -17,7 +17,7 @@ describe "extract_marc" do
 
 
   it "extracts marc" do
-    @indexer.instance_eval do
+    @indexer.configure do
       to_field "title", extract_marc("245ab")
     end
 
@@ -29,7 +29,7 @@ describe "extract_marc" do
   end
 
   it "respects :first=>true option" do
-    @indexer.instance_eval do
+    @indexer.configure do
       to_field "other_id", extract_marc("035a", :first => true)
     end
 
@@ -40,7 +40,7 @@ describe "extract_marc" do
   end
 
   it "trims punctuation with :trim_punctuation => true" do
-    @indexer.instance_eval do
+    @indexer.configure do
       to_field "title", extract_marc("245ab", :trim_punctuation => true)
     end
 
@@ -51,7 +51,7 @@ describe "extract_marc" do
   end
 
   it "can use trim_punctuation as transformation macro" do
-    @indexer.instance_eval do
+    @indexer.configure do
       to_field "title", extract_marc("245ab"), trim_punctuation
     end
 
@@ -62,7 +62,7 @@ describe "extract_marc" do
   end
 
   it "respects :default option" do
-    @indexer.instance_eval do
+    @indexer.configure do
       to_field "only_default", extract_marc("9999", :default => "DEFAULT VALUE")
     end
     output = @indexer.map_record(@record)
@@ -75,7 +75,7 @@ describe "extract_marc" do
     f = @record.fields('008').first
     @record.append(f)
 
-    @indexer.instance_eval do
+    @indexer.configure do
       to_field "lang1", extract_marc('008[35-37]')
       to_field "lang2", extract_marc('008[35-37]', :allow_duplicates => true)
     end
@@ -88,7 +88,7 @@ describe "extract_marc" do
 
   it "fails on an extra/misspelled argument to extract_marc" do
     assert_raises(RuntimeError) do
-      @indexer.instance_eval do
+      @indexer.configure do
         to_field "foo", extract_marc("9999", :misspelled => "Who cares")
       end
     end
@@ -96,7 +96,7 @@ describe "extract_marc" do
 
 
   it "throws away nil values unless settings['allow_nil_values]'" do
-    @indexer.instance_eval do
+    @indexer.configure do
       to_field 'default_nil', extract_marc('9999', :default => nil)
     end
     output = @indexer.map_record(@record)
@@ -108,7 +108,7 @@ describe "extract_marc" do
     @indexer.settings do |s|
       s['allow_nil_values'] = true
     end
-    @indexer.instance_eval do
+    @indexer.configure do
       to_field 'default_nil', extract_marc('9999', :default => nil)
     end
     output = @indexer.map_record(@record)
@@ -119,7 +119,7 @@ describe "extract_marc" do
 
 
   it "uses :translation_map" do
-    @indexer.instance_eval do
+    @indexer.configure do
       to_field "cataloging_agency", extract_marc("040a", :separator => nil, :translation_map => "marc_040a_translate_test")
     end
     output = @indexer.map_record(@record)

--- a/test/indexer/macros/marc21/serialize_marc_test.rb
+++ b/test/indexer/macros/marc21/serialize_marc_test.rb
@@ -15,7 +15,7 @@ describe "serialized_marc" do
   end
 
   it "serializes xml" do
-    @indexer.instance_eval do
+    @indexer.configure do
       to_field "marc_record", serialized_marc(:format => "xml")
     end
     output = @indexer.map_record(@record)
@@ -27,7 +27,7 @@ describe "serialized_marc" do
   end
 
   it "serializes binary UUEncoded" do
-    @indexer.instance_eval do
+    @indexer.configure do
       to_field "marc_record", serialized_marc(:format => "binary")
     end
     output = @indexer.map_record(@record)
@@ -42,7 +42,7 @@ describe "serialized_marc" do
   end
 
   it "serializes binary raw" do
-    @indexer.instance_eval do
+    @indexer.configure do
       to_field "marc_record", serialized_marc(:format => "binary", :binary_escape => false)
     end
     output = @indexer.map_record(@record)
@@ -55,7 +55,7 @@ describe "serialized_marc" do
   end
 
   it "serializes json" do
-    @indexer.instance_eval do
+    @indexer.configure do
       to_field "marc_record", serialized_marc(:format => "json")
     end
     output = @indexer.map_record(@record)

--- a/test/indexer/macros/to_field_test.rb
+++ b/test/indexer/macros/to_field_test.rb
@@ -7,7 +7,7 @@ describe "Indexer Macros#to_field" do
   end
 
   it "works with simple literal" do
-    @indexer.instance_eval do
+    @indexer.configure do
       extend Traject::Macros::Basic
 
       to_field "source", literal("MY LIBRARY")
@@ -21,7 +21,7 @@ describe "Indexer Macros#to_field" do
   it "works with macro AND block" do
     called = false
 
-    @indexer.instance_eval do
+    @indexer.configure do
       extend Traject::Macros::Basic
       to_field "source", literal("MY LIBRARY") do |record, accumulator, context|
         called = true

--- a/test/indexer/macros/transformation_test.rb
+++ b/test/indexer/macros/transformation_test.rb
@@ -12,7 +12,7 @@ describe "Traject::Macros::Transformation" do
 
   describe "translation_map" do
     it "translates" do
-      @indexer.instance_eval do
+      @indexer.configure do
         to_field "cataloging_agency", literal("DLC"), translation_map("marc_040a_translate_test")
       end
       output = @indexer.map_record(@record)
@@ -22,7 +22,7 @@ describe "Traject::Macros::Transformation" do
 
   describe "transform" do
     it "transforms with block" do
-      @indexer.instance_eval do
+      @indexer.configure do
         to_field "sample_field", literal("one"), literal("two"), transform(&:upcase)
       end
       output = @indexer.map_record(@record)
@@ -30,7 +30,7 @@ describe "Traject::Macros::Transformation" do
     end
 
     it "transforms with proc arg" do
-      @indexer.instance_eval do
+      @indexer.configure do
         to_field "sample_field", literal("one"), literal("two"), transform(->(val) { val.tr('aeiou', '!') })
       end
       output = @indexer.map_record(@record)
@@ -38,7 +38,7 @@ describe "Traject::Macros::Transformation" do
     end
 
     it "transforms with both, in correct order" do
-      @indexer.instance_eval do
+      @indexer.configure do
         to_field "sample_field", literal("one"), literal("two"), transform(->(val) { val.tr('aeiou', '!') }, &:upcase)
       end
       output = @indexer.map_record(@record)
@@ -48,7 +48,7 @@ describe "Traject::Macros::Transformation" do
 
   describe "default" do
     it "adds default to empty accumulator" do
-      @indexer.instance_eval do
+      @indexer.configure do
         to_field "test", default("default")
       end
       output = @indexer.map_record(@record)
@@ -56,7 +56,7 @@ describe "Traject::Macros::Transformation" do
     end
 
     it "does not add default if value present" do
-      @indexer.instance_eval do
+      @indexer.configure do
         to_field "test", literal("value"), default("defaut")
       end
       output = @indexer.map_record(@record)
@@ -66,7 +66,7 @@ describe "Traject::Macros::Transformation" do
 
   describe "first_only" do
     it "takes only first in multi-value" do
-      @indexer.instance_eval do
+      @indexer.configure do
         to_field "test", literal("one"), literal("two"), literal("three"), first_only
       end
       output = @indexer.map_record(@record)
@@ -74,7 +74,7 @@ describe "Traject::Macros::Transformation" do
     end
 
     it "no-ops on nil" do
-      @indexer.instance_eval do
+      @indexer.configure do
         to_field "test", first_only
       end
       output = @indexer.map_record(@record)
@@ -82,7 +82,7 @@ describe "Traject::Macros::Transformation" do
     end
 
     it "no-ops on single value" do
-      @indexer.instance_eval do
+      @indexer.configure do
         to_field "test", literal("one"), first_only
       end
       output = @indexer.map_record(@record)
@@ -92,7 +92,7 @@ describe "Traject::Macros::Transformation" do
 
   describe "unique" do
     it "uniqs" do
-      @indexer.instance_eval do
+      @indexer.configure do
         to_field "test", literal("one"), literal("two"), literal("one"), literal("three"), unique
       end
       output = @indexer.map_record(@record)
@@ -102,7 +102,7 @@ describe "Traject::Macros::Transformation" do
 
   describe "strip" do
     it "strips" do
-      @indexer.instance_eval do
+      @indexer.configure do
         to_field "test", literal("  one"), literal(" two  "), strip
       end
       output = @indexer.map_record(@record)
@@ -110,7 +110,7 @@ describe "Traject::Macros::Transformation" do
     end
 
     it "strips unicode whitespace" do
-      @indexer.instance_eval do
+      @indexer.configure do
         to_field "test", literal(" \u00A0 \u2002 one \u202F "), strip
       end
       output = @indexer.map_record(@record)
@@ -120,7 +120,7 @@ describe "Traject::Macros::Transformation" do
 
   describe "split" do
     it "splits" do
-      @indexer.instance_eval do
+      @indexer.configure do
         to_field "test", literal("one.two"), split(".")
       end
       output = @indexer.map_record(@record)
@@ -130,7 +130,7 @@ describe "Traject::Macros::Transformation" do
 
   describe "append" do
     it "appends suffix" do
-      @indexer.instance_eval do
+      @indexer.configure do
         to_field "test", literal("one"), literal("two"), append(".suffix")
       end
       output = @indexer.map_record(@record)
@@ -140,7 +140,7 @@ describe "Traject::Macros::Transformation" do
 
   describe "prepend" do
     it "prepends prefix" do
-      @indexer.instance_eval do
+      @indexer.configure do
         to_field "test", literal("one"), literal("two"), prepend("prefix.")
       end
       output = @indexer.map_record(@record)
@@ -150,7 +150,7 @@ describe "Traject::Macros::Transformation" do
 
   describe "gsub" do
     it "gsubs" do
-      @indexer.instance_eval do
+      @indexer.configure do
         to_field "test", literal("one1212two23three"), gsub(/\d+/, ' ')
       end
       output = @indexer.map_record(@record)

--- a/test/indexer/settings_test.rb
+++ b/test/indexer/settings_test.rb
@@ -38,7 +38,7 @@ describe "Traject::Indexer#settings" do
   end
 
   it "has settings DSL to set" do
-    @indexer.instance_eval do
+    @indexer.configure do
       settings do
         store "foo", "foo"
       end


### PR DESCRIPTION
For now it just does an instance_eval, but is clearer and safer for future compat.