### PR TITLE
Traject command line can take multiple files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,8 @@
 
 * Traject::Indexer#configure is available, and recommended instead of raw `instance_eval`. It just does an instance_eval, but is clearer and safer for future changes.
 
+* Traject::Indexer#process can take an array of input streams.
+
 * `to_field` can now take an array as a first argument, to send values to multiple fields mentioned, eg:
 
       to_field ["field1", "field2"], extract_marc("240")

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,7 +22,7 @@
 
 * Traject::Indexer#configure is available, and recommended instead of raw `instance_eval`. It just does an instance_eval, but is clearer and safer for future changes.
 
-* Traject::Indexer#process can take an array of input streams.
+* traject command line can now take multiple input files. And underlying it, Traject::Indexer#process can take an array of input streams.
 
 * `to_field` can now take an array as a first argument, to send values to multiple fields mentioned, eg:
 

--- a/lib/traject/command_line.rb
+++ b/lib/traject/command_line.rb
@@ -135,37 +135,23 @@ module Traject
       return true
     end
 
+    # @return (Array<#read>, String)
     def get_input_io(argv)
-      # ARGF might be perfect for this, but problems with it include:
-      # * jruby is broken, no way to set it's encoding, leads to encoding errors reading non-ascii
-      #   https://github.com/jruby/jruby/issues/891
-      # * It's apparently not enough like an IO object for at least one of the ruby-marc XML
-      #   readers:
-      #   NoMethodError: undefined method `to_inputstream' for ARGF:Object
-      #      init at /Users/jrochkind/.gem/jruby/1.9.3/gems/marc-0.5.1/lib/marc/xml_parsers.rb:369
-      #
-      # * It INSISTS on reading from ARGFV, making it hard to test, or use when you want to give
-      #   it a list of files on something other than ARGV.
-      #
-      # So for now we do just one file, or stdin if specified. Sorry!
-
       filename = nil
+      io_arr = nil
       if options[:stdin]
         indexer.logger.info("Reading from standard input")
-        io = $stdin
-      elsif argv.length > 1
-        self.console.puts "Sorry, traject can only handle one input file at a time right now. `#{argv}` Exiting..."
-        exit 1
+        io_arr = [$stdin]
       elsif argv.length == 0
-        io = File.open(File::NULL, 'r')
+        io_arr = [File.open(File::NULL, 'r')]
         indexer.logger.info("Warning, no file input given. Use command-line argument '--stdin' to use standard input ")
       else
-        io = File.open(argv.first, 'r')
-        filename = argv.first
+        io_arr = argv.collect { |path| File.open(path, 'r') }
+        filename = argv.join(",")
         indexer.logger.info "Reading from #{filename}"
       end
 
-      return io, filename
+      return io_arr, filename
     end
 
     def load_configuration_files!(my_indexer, conf_files)

--- a/lib/traject/debug_writer.rb
+++ b/lib/traject/debug_writer.rb
@@ -51,7 +51,7 @@ class Traject::DebugWriter < Traject::LineWriter
       context.output_hash[@idfield].first
     else
       unless @already_threw_warning_about_missing_id
-        context.logger.warn "At least one record (##{context.position}) doesn't define field '#{@idfield}'.
+        context.logger.warn "At least one record (#{context.record_inspect}) doesn't define field '#{@idfield}'.
 All records are assumed to have a unique id. You can set which field to look in via the setting 'debug_writer.idfield'"
         @already_threw_warning_about_missing_id = true
       end

--- a/lib/traject/ndj_reader.rb
+++ b/lib/traject/ndj_reader.rb
@@ -12,7 +12,7 @@ class Traject::NDJReader
   def initialize(input_stream, settings)
     @settings = settings
     @input_stream = input_stream
-    if /\.gz\Z/.match(@settings['command_line.filename'])
+    if input_stream.respond_to?(:path) && /\.gz\Z/.match(input_stream.path)
       @input_stream = Zlib::GzipReader.new(@input_stream, :external_encoding => "UTF-8")
     end
   end

--- a/lib/traject/solr_json_writer.rb
+++ b/lib/traject/solr_json_writer.rb
@@ -161,7 +161,7 @@ class Traject::SolrJsonWriter
       else
         msg = "Solr error response: #{resp.status}: #{resp.body}"
       end
-      logger.error "Could not add record #{c.source_record_id} at source file position #{c.position}: #{msg}"
+      logger.error "Could not add record #{c.record_inspect}: #{msg}"
       logger.debug(c.source_record.to_s)
 
       @skipped_record_incrementer.increment

--- a/lib/traject/util.rb
+++ b/lib/traject/util.rb
@@ -124,5 +124,11 @@ module Traject
       return result
     end
 
+    # How can we refer to an io object input in logs? For now, if it's a file-like
+    # object, we can use #path.
+    def self.io_name(io_like_object)
+      io_like_object.path if io_like_object.respond_to?(:path)
+    end
+
   end
 end

--- a/test/debug_writer_test.rb
+++ b/test/debug_writer_test.rb
@@ -46,7 +46,7 @@ describe 'Simple output' do
         "record_num_1 title #{@title}",
     ]
     assert_equal expected.join("\n").gsub(/\s/, ''), @io.string.gsub(/\s/, '')
-    assert_match /At least one record \(\#1\) doesn't define field 'id'/, logger_strio.string
+    assert_match /At least one record \(<record #1>\) doesn't define field 'id'/, logger_strio.string
     @writer.close
 
   end
@@ -68,7 +68,7 @@ describe 'Simple output' do
         "record_num_1 title #{@title}",
     ]
     assert_equal expected.join("\n").gsub(/\s/, ''), @io.string.gsub(/\s/, '')
-    assert_match /At least one record \(\#1\) doesn't define field 'iden'/, logger_strio.string
+    assert_match /At least one record \(<record #1, output_id:2710183>\) doesn't define field 'iden'/, logger_strio.string
     writer.close
 
   end

--- a/test/indexer/context_test.rb
+++ b/test/indexer/context_test.rb
@@ -13,23 +13,33 @@ describe "Traject::Indexer::Context" do
       @context.source_record = @record
       assert_equal @record_001, @context.source_record_id
     end
-
-    it "gets it from the id" do
-      @context.output_hash['id'] = 'the_record_id'
-      assert_equal 'the_record_id', @context.source_record_id
-    end
-
-    it "gets from the id with non-MARC source" do
-      @context.source_record = Object.new
-      @context.output_hash['id'] = 'the_record_id'
-      assert_equal 'the_record_id', @context.source_record_id
-    end
-
-    it "gets it from both 001 and id" do
-      @context.output_hash['id'] = 'the_record_id'
-      @context.source_record = @record
-      assert_equal [@record_001, 'the_record_id'].join('/'), @context.source_record_id
-    end
   end
+
+  describe "#record_inspect" do
+    before do
+      @record = MARC::Reader.new(support_file_path('test_data.utf8.mrc')).first
+      @source_record_id_proc = Traject::Indexer::MarcIndexer.new.source_record_id_proc
+      @record_001 = "   00282214 " # from the mrc file
+
+      @position = 10
+      @input_name = "some_file.mrc"
+      @position_in_input = 10
+    end
+
+    it "can print complete inspect label" do
+      @context = Traject::Indexer::Context.new(
+        source_record:  @record,
+        source_record_id_proc: @source_record_id_proc,
+        position: @position,
+        input_name: @input_name,
+        position_in_input: @position_in_input
+      )
+      @context.output_hash["id"] = "output_id"
+
+      assert_equal "<record ##{@position} (#{@input_name} ##{@position_in_input}), source_id:#{@record_001} output_id:output_id>", @context.record_inspect
+    end
+
+  end
+
 
 end

--- a/test/indexer/read_write_test.rb
+++ b/test/indexer/read_write_test.rb
@@ -133,4 +133,23 @@ describe "Traject::Indexer#process" do
     end
   end
 
+  describe "multi stream" do
+    before do
+      @file2 = File.open(support_file_path "george_eliot.marc")
+      @file1 = File.open(support_file_path "musical_cage.marc")
+      @indexer = Traject::Indexer::MarcIndexer.new do
+        self.writer_class = memory_writer_class
+        to_field "title", extract_marc("245")
+      end
+    end
+
+    it "parses and loads" do
+      @indexer.process([@file1, @file2])
+      # kinda ridic, yeah.
+      output_hashes = memory_writer_class.class_variable_get("@@last_writer_settings")["memory_writer.added"].collect(&:output_hash)
+
+      assert_length 2, output_hashes
+      assert output_hashes.all? { |hash| hash["title"].length > 0 }
+    end
+  end
 end

--- a/test/solr_json_writer_test.rb
+++ b/test/solr_json_writer_test.rb
@@ -184,7 +184,7 @@ describe "Traject::SolrJsonWriter" do
       logged = strio.string
 
       10.times do |i|
-        assert_match /ERROR.*Could not add record doc_#{i} at source file position : Solr error response: 500/, logged
+        assert_match /ERROR.*Could not add record <output_id:doc_#{i}>: Solr error response: 500/, logged
       end
     end
 


### PR DESCRIPTION
And Indexer#process can take an array of input streams to handle

With better reference to records in logs and errors, mentioning input file name where possible.