### PR TITLE
drop MRI 2.2 support prior to 3.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ cache: bundler
 # at downloading jruby, and
 sudo: true
 rvm:
-  - 2.2.9
   - 2.3.6
   - 2.4.3
   - 2.5.1
+  - "2.6.0-preview2"
 # avoid having travis install jdk on MRI builds where we don't need it.
 matrix:
   include:
@@ -15,4 +15,5 @@ matrix:
       rvm: jruby-9.0.5.0
     - jdk: oraclejdk8
       rvm: jruby-9.2.0.0
-
+  allow_failures:
+    - rvm: "2.6.0-preview2"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Initially by Jonathan Rochkind (Johns Hopkins Libraries) and Bill Dueber (Univer
 
 ## Installation
 
-Traject runs under jruby (9.0.x or higher), MRI ruby (2.2.x or higher), or probably any other ruby platform.
+Traject runs under jruby (9.0.x or higher), MRI ruby (2.3.x or higher), or probably any other ruby platform.
 
 **Traject runs much faster on JRuby** where it can use multi-core parallelism, and the Java Marc4J marc reader. If performance is a concern, you should run traject on JRuby.
 


### PR DESCRIPTION
2.2 is already EOL with not even security updates
https://www.ruby-lang.org/en/downloads/branches/