### PR TITLE
Reduce noise in console under testing

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,6 +11,13 @@ require 'rake/testtask'
 task :default => [:test]
 
 Rake::TestTask.new do |t|
+  # Rake 11 makes warnings on by default, but there is so much noise, including
+  # from our dependencies, and from things I think are silly warnings like
+  # "shadowing outer local variable"
+  # Possibly could turn back on in the future using https://rubygems.org/gems/warning/versions/0.10.0
+  # gem to customize.
+  t.warning = false
+
   t.pattern = 'test/**/*_test.rb'
   t.libs.push 'test', 'test_support'
 end

--- a/lib/traject/indexer.rb
+++ b/lib/traject/indexer.rb
@@ -177,6 +177,7 @@ class Traject::Indexer
   # optionally takes a block which is instance_eval'd in the indexer,
   # intended for configuration simimlar to what would be in a config file.
   def initialize(arg_settings = {}, &block)
+    @writer_class           = nil
     @completed              = false
     @settings               = Settings.new(arg_settings).with_defaults(self.class.default_settings)
     @index_steps            = []
@@ -242,7 +243,7 @@ class Traject::Indexer
   def settings(new_settings = nil, &block)
     @settings.merge!(new_settings) if new_settings
 
-    @settings.instance_eval &block if block_given?
+    @settings.instance_eval(&block) if block_given?
 
     return @settings
   end
@@ -557,12 +558,12 @@ class Traject::Indexer
         # We pass context in a block arg to properly 'capture' it, so
         # we don't accidentally share the local var under closure between
         # threads.
-        thread_pool.maybe_in_thread_pool(context) do |context|
-          map_to_context!(context)
+        thread_pool.maybe_in_thread_pool(context) do |t_context|
+          map_to_context!(t_context)
           if context.skip?
-            log_skip(context)
+            log_skip(t_context)
           else
-            writer.put context
+            writer.put t_context
           end
         end
       end

--- a/lib/traject/indexer/step.rb
+++ b/lib/traject/indexer/step.rb
@@ -30,15 +30,15 @@ class Traject::Indexer
     # Set the arity of the lambda expression just once, when we define it
     def lambda=(lam)
       @lambda_arity = 0 # assume
+      @lambda = lam
+
       return unless lam
 
-      @lambda = lam
       if @lambda.is_a?(Proc)
         @lambda_arity = @lambda.arity
       else
         raise NamingError.new("argument to each_record must be a block/lambda, not a #{lam.class} #{self.inspect}")
       end
-
     end
 
     # raises if bad data

--- a/lib/traject/oai_pmh_nokogiri_reader.rb
+++ b/lib/traject/oai_pmh_nokogiri_reader.rb
@@ -153,9 +153,6 @@ module Traject
       reader.each { |d| yield d }
 
       return reader.clipboard[:resumption_token]
-    rescue RuntimeError => e
-      byebug
-      1+1
     end
 
   end

--- a/lib/traject/util.rb
+++ b/lib/traject/util.rb
@@ -60,7 +60,6 @@ module Traject
           if line.start_with?(file_path)
             if m = /\A.*\:(\d+)\:in/.match(line)
               return m[1].to_i
-              break
             end
           end
         end

--- a/test/debug_writer_test.rb
+++ b/test/debug_writer_test.rb
@@ -46,7 +46,7 @@ describe 'Simple output' do
         "record_num_1 title #{@title}",
     ]
     assert_equal expected.join("\n").gsub(/\s/, ''), @io.string.gsub(/\s/, '')
-    assert_match /At least one record \(<record #1>\) doesn't define field 'id'/, logger_strio.string
+    assert_match(/At least one record \(<record #1>\) doesn't define field 'id'/, logger_strio.string)
     @writer.close
 
   end
@@ -68,7 +68,7 @@ describe 'Simple output' do
         "record_num_1 title #{@title}",
     ]
     assert_equal expected.join("\n").gsub(/\s/, ''), @io.string.gsub(/\s/, '')
-    assert_match /At least one record \(<record #1, output_id:2710183>\) doesn't define field 'iden'/, logger_strio.string
+    assert_match(/At least one record \(<record #1, output_id:2710183>\) doesn't define field 'iden'/, logger_strio.string)
     writer.close
 
   end

--- a/test/delimited_writer_test.rb
+++ b/test/delimited_writer_test.rb
@@ -39,13 +39,13 @@ describe "Delimited/CSV Writers" do
     end
 
     it "outputs a header if asked to" do
-      dw = Traject::DelimitedWriter.new(@settings)
+      Traject::DelimitedWriter.new(@settings)
       @out.string.chomp.must_equal %w[four one two].join("\t")
     end
 
     it "doesn't output a header if asked not to" do
       @settings['delimited_writer.header'] = 'false'
-      dw                                   = Traject::DelimitedWriter.new(@settings)
+      Traject::DelimitedWriter.new(@settings)
       @out.string.must_be_empty
     end
 
@@ -69,7 +69,7 @@ describe "Delimited/CSV Writers" do
     end
 
     it "writes the header" do
-      cw = Traject::CSVWriter.new(@settings)
+      Traject::CSVWriter.new(@settings)
       @out.string.chomp.must_equal 'four,one,two'
     end
 

--- a/test/indexer/process_with_test.rb
+++ b/test/indexer/process_with_test.rb
@@ -101,7 +101,7 @@ describe "Traject::Indexer#process_with" do
           }
         end
 
-        writer = indexer.process_with(input_records, array_writer, rescue_with: rescue_lambda)
+        _writer = indexer.process_with(input_records, array_writer, rescue_with: rescue_lambda)
 
         # not including the one that raised
         assert_equal 2, array_writer.contexts.length

--- a/test/marc_extractor_test.rb
+++ b/test/marc_extractor_test.rb
@@ -28,7 +28,7 @@ describe "Traject::MarcExtractor" do
 
       assert_kind_of Array, spec.subfields
     end
-    
+
     it "parses specset from an array" do
       parsed  = Traject::MarcExtractor::SpecSet.new(%w[245abcde 810 700|*4|bcd])
       assert_equal parsed.tags, %w[245 810 700]
@@ -60,17 +60,17 @@ describe "Traject::MarcExtractor" do
       assert_equal "4", spec700.indicator2
       assert_equal %w{b c d}, spec700.subfields
     end
-    
+
     it "parses from an array" do
       parsed  = Traject::MarcExtractor::Spec.hash_from_string(%w[245abcde 810 700|*4|bcd])
-      spec245 = parsed['245'].first
-      spec810 = parsed['810'].first
-      spec700 = parsed['700'].first
+      _spec245 = parsed['245'].first
+      _spec810 = parsed['810'].first
+      _spec700 = parsed['700'].first
 
       assert_length 3, parsed
     end
-      
-      
+
+
 
     it "parses fixed field byte offsets" do
       parsed = Traject::MarcExtractor::Spec.hash_from_string("005[5]:008[7-10]")

--- a/test/marc_reader_test.rb
+++ b/test/marc_reader_test.rb
@@ -50,13 +50,13 @@ describe "Traject::MarcReader" do
       a245a = array.first['245']['a']
 
       assert a245a.encoding.name, "UTF-8"
-      assert a245a.valid_encoding?    
+      assert a245a.valid_encoding?
       assert_equal "Por uma outra globalização :", a245a
     end
 
     it "replaces unicode character reference in Marc8 transcode" do
       file = File.new(support_file_path("escaped_character_reference.marc8.marc"))
-      
+
       settings = Traject::Indexer::Settings.new("marc_source.encoding" => "MARC-8") # binary type is default
       record = Traject::MarcReader.new(file, settings).to_a.first
 
@@ -67,7 +67,7 @@ describe "Traject::MarcReader" do
       file = File.new(support_file_path "one-marc8.mrc")
       settings = Traject::Indexer::Settings.new("marc_source.encoding" => "ADFADFADF")
       assert_raises(ArgumentError) do
-        record = Traject::MarcReader.new(file, settings).to_a.first
+        _record = Traject::MarcReader.new(file, settings).to_a.first
       end
     end
 
@@ -78,7 +78,7 @@ describe "Traject::MarcReader" do
       reader = Traject::MarcReader.new(file, settings)
 
       record = reader.to_a.first
-      
+
       value = record['300']['a']
 
       assert_equal value.encoding.name, "UTF-8"

--- a/test/solr_json_writer_test.rb
+++ b/test/solr_json_writer_test.rb
@@ -41,7 +41,7 @@ describe "Traject::SolrJsonWriter" do
       return resp
     end
 
-    def get (*args)
+    def get(*args)
       @mutex.synchronize do
         @get_args << args
       end
@@ -184,7 +184,7 @@ describe "Traject::SolrJsonWriter" do
       logged = strio.string
 
       10.times do |i|
-        assert_match /ERROR.*Could not add record <output_id:doc_#{i}>: Solr error response: 500/, logged
+        assert_match(/ERROR.*Could not add record <output_id:doc_#{i}>: Solr error response: 500/, logged)
       end
     end
 
@@ -206,7 +206,7 @@ describe "Traject::SolrJsonWriter" do
       @writer = create_writer("solr_writer.max_skipped" => 0)
       @fake_http_client.response_status = 500
 
-      e = assert_raises(RuntimeError) do
+      _e = assert_raises(RuntimeError) do
         @writer.put context_with("id" => "doc_1", "key" => "value")
         @writer.close
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,7 +14,12 @@ STDERR.sync = true
 
 # Hacky way to turn off Indexer logging by default, say only
 # log things higher than fatal, which is nothing.
-Traject::Indexer.send(:default_settings=, Traject::Indexer.default_settings.merge("log.level" => "gt.fatal"))
+Traject::Indexer.singleton_class.prepend(Module.new do
+  def default_settings
+    super.merge("log.level" => "gt.fatal")
+  end
+end)
+
 
 def support_file_path(relative_path)
   return File.expand_path(File.join("test_support", relative_path), File.dirname(__FILE__))

--- a/test/translation_map_test.rb
+++ b/test/translation_map_test.rb
@@ -57,7 +57,7 @@ describe "TranslationMap" do
 
     it "raises on syntax error in yaml" do
       exception = assert_raises(Psych::SyntaxError) do
-        found = @cache.lookup("bad_yaml")
+        _found = @cache.lookup("bad_yaml")
       end
 
       assert  exception.message.include?("bad_yaml.yaml"), "exception message includes source file"
@@ -65,7 +65,7 @@ describe "TranslationMap" do
 
     it "raises on syntax error in ruby" do
       exception = assert_raises(SyntaxError) do
-        found = @cache.lookup("bad_ruby")
+        _found = @cache.lookup("bad_ruby")
       end
       assert  exception.message.include?("bad_ruby.rb"), "exception message includes source file"
     end
@@ -118,7 +118,7 @@ describe "TranslationMap" do
 
     assert_equal "DEFAULT LITERAL", map["not in the map"]
   end
-  
+
   it "respects __default__ __passthrough__" do
     map = Traject::TranslationMap.new("default_passthrough")
 


### PR DESCRIPTION
* Fix some `ruby -w` warnings (ruby -w is on by default in rake tasks in rake 11+)
* fix hacky way to disable logging under test
* actually disable -w, it's too much noise, espeically from gems. Possibly could re-enable in future with the [warning](https://rubygems.org/gems/warning/versions/0.10.0) gem to customize, but it is pre-1.0 and only works on ruby 2.3+.  In general the "warning" feature seems little used in ruby community, many dependencies trigger warnings, some of the warnings seem silly to me. Rake's decision to turn it on by default seems questionable. 