### PR TITLE
Remove separate JRuby release with traject-marc4j_reader dependency

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
 * Placeholder
 
+* JRuby traject no longer includes `traject-marc4j_reader`, as a dependency, but the `Traject::Marc4JReader` contained there is still the JRuby MARC reading default. You will need to install that gem yourself, or add it to your Gemfile. See https://github.com/traject/traject/pull/187
+
 * `map_record` now returns `nil` if record was skipped.
 
 * The `Traject::Indexer` class no longer includes marc-specific settings and modules.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 
 * Placeholder
 
-* JRuby traject no longer includes `traject-marc4j_reader`, as a dependency, but the `Traject::Marc4JReader` contained there is still the JRuby MARC reading default. You will need to install that gem yourself, or add it to your Gemfile. See https://github.com/traject/traject/pull/187
+* JRuby traject no longer includes `traject-marc4j_reader` as a dependency or default reader, although it may provide faster MARC-XML reading on JRuby. To use it manually, see https://github.com/traject/traject-marc4j_reader . See https://github.com/traject/traject/pull/187
 
 * `map_record` now returns `nil` if record was skipped.
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,9 @@ gemspec
 
 group :development do
   gem "webmock", "~> 3.4"
+
+  # No longer in our gemspec, but we need it for testing MARC under JRuby.
+  gem "traject-marc4j_reader", "~> 1.0", platform: "jruby"
 end
 
 group :debug do

--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,6 @@ gemspec
 
 group :development do
   gem "webmock", "~> 3.4"
-
-  # No longer in our gemspec, but we need it for testing MARC under JRuby.
-  gem "traject-marc4j_reader", "~> 1.0", platform: "jruby"
 end
 
 group :debug do

--- a/README.md
+++ b/README.md
@@ -28,13 +28,12 @@ Initially by Jonathan Rochkind (Johns Hopkins Libraries) and Bill Dueber (Univer
 
 Traject runs under jruby (9.0.x or higher), MRI ruby (2.3.x or higher), or probably any other ruby platform.
 
-We think, at least for MARC input, **traject should run much faster on JRuby** where it can use multi-core parallelism, and the Java Marc4J marc reader. If performance is a concern, you should measure timing running traject on JRuby. (This likely does not apply to XML input)
+Once you have ruby installed, just `$ gem install traject`.
+
+**If you are processing MARC input, you will probably get significant performance improvements on JRuby.** If you are processing Marc-XML (rather than binary Marc21), you should additionally get even more performance improvements by using the [traject-marc4j_reader](https://github.com/traject/traject-marc4j_reader) gem on JRuby (see installation instructions there). If performance is a concern, and you are processing MARC, we recommend benchmarking traject on JRuby. (JRuby is not currently recommended for non-MARC XML input.)
 
 Some options for installing a ruby other than your system-provided one are [chruby](https://github.com/postmodern/chruby) and [ruby-install](https://github.com/postmodern/ruby-install#readme).
 
-Once you have ruby, just `$ gem install traject`.
-
-**If you are using JRuby _and_ MARC processing**, also `$ gem install 'traject-marc4j_reader'`, to install the JRuby MARC reader used as default for MARC reading under JRuby.
 
 ## Configuration files
 
@@ -75,8 +74,8 @@ settings do
   provide "solr_writer.commit_on_close", "true"
 
   # The default writer is the Traject::SolrJsonWriter. In the default MARC mode,
-  # the default reader is Marc4JReader (using Java Marc4J library) on Jruby,
-  # MarcReader (using ruby-marc) otherwise. In XML mode, it is the NokogiriReader.
+  # the default reader in MARC mode is MarcReader (using ruby-marc).
+  # In XML mode, it is the NokogiriReader.
 end
 ~~~
 
@@ -501,8 +500,7 @@ Own Code](./doc/extending.md)
   * [traject_horizon](https://github.com/jrochkind/traject_horizon): Export MARC records directly from a Horizon ILS rdbms, as serialized MARC or to  index into Solr.
   * [traject_umich_format](https://github.com/billdueber/traject_umich_format/): opinionated code and associated macros to extract format (book, audio file, etc.) and types (bibliography, conference report, etc.) from a MARC record. Code mirrors that used by the University of Michigan, and is an alternate approach to that taken by the `marc_formats` macro in `Traject::Macros::MarcFormatClassifier`.
   * [traject-solrj_writer](https://github.com/traject/traject-solrj_writer): a jruby-only writer that uses the solrj .jar to talk directly to solr. Your only option for speaking to a solr version < 3.2, which is when the json handler was added to solr.
-  * [traject_marc4j_reader](https://github.com/traject/traject-marc4j_reader): Packaged with traject automatically on jruby. A JRuby-only reader for
-  reading marc records using the Marc4J library, fastest MARC reading on JRuby.
+  * [traject_marc4j_reader](https://github.com/traject/traject-marc4j_reader): A JRuby-only reader for reading marc records using the Marc4J library, fastest MARC-XML reading on JRuby.
   * [traject_sequel_writer](https://github.com/traject/traject_sequel_writer) A writer for sending to an rdbms via [Sequel](https://github.com/jeremyevans/sequel)
 
 # Development

--- a/README.md
+++ b/README.md
@@ -519,9 +519,6 @@ and/or extra files in ./docs -- as appropriate for what needs to be docs.
 online api docs has a `--markup markdown` specified -- inline class/method docs are in markdown, not rdoc.
 
 Bundler rake tasks included for gem releases: `rake release`
-* Every traject release needs to be done once when running MRI, and switch to JRuby
-and do the same release again. The JRuby release is identical but for including
-a gemspec dependency on the Marc4JReader gem.
 
 ## TODO: Possible future enhancements
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Some options for installing a ruby other than your system-provided one are [chru
 
 Once you have ruby, just `$ gem install traject`.
 
+**If you are using JRuby _and_ MARC processing**, also `$ gem install 'traject-marc4j_reader'`, to install the JRuby MARC reader used as default for MARC reading under JRuby.
+
 ## Configuration files
 
 traject is configured using configuration files. To get a sense of what they look like, you can take a look at our sample basic [MARC configuration file](./test/test_support/demo_config.rb) or [XML configuration file](./test/test_support/nokogiri_demo_config.rb). You could run traject with that configuration file as: `traject -c path/to/demo_config.rb marc_file.marc`.

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -28,7 +28,7 @@ settings are applied first of all. It's recommended you use `provide`.
 
 ### Reading (general)
 
-* `reader_class_name`: a Traject Reader class, used by the indexer as a source of records.   Defaults to Traject::Marc4JReader (using the Java Marc4J library) on JRuby; Traject::MarcReader (using the ruby marc gem) otherwise. Command-line shortcut `-r`
+* `reader_class_name`: a Traject Reader class, used by the indexer as a source of records.   Defaults is reader-specific: Traject::MarcReader (using the ruby marc gem) or Traject::NokogiriReader.Command-line shortcut `-r`
 
 ### Error handling
 

--- a/lib/traject/indexer.rb
+++ b/lib/traject/indexer.rb
@@ -297,17 +297,11 @@ class Traject::Indexer
     # include legacy Marc macros
     include Traject::Macros::Marc21
 
-    # alter default settings to be legacy including marc-specific
-    is_jruby = defined?(JRUBY_VERSION)
-
     # Reader defaults
     legacy_settings = {
-      "reader_class_name"       => is_jruby ? "Traject::Marc4JReader" : "Traject::MarcReader",
+      "reader_class_name"       => "Traject::MarcReader",
       "marc_source.type"        => "binary",
     }
-    if is_jruby
-      legacy_settings["marc4j_reader.permissive"] = true
-    end
 
     default_settings.merge!(legacy_settings)
 
@@ -721,21 +715,6 @@ class Traject::Indexer
   def reader_class
     unless defined? @reader_class
       reader_class_name = settings["reader_class_name"]
-
-      if reader_class_name == "Traject::Marc4JReader"
-        # special handling since this is JRuby MARC default, but is in another gem.
-        # It used to be a dependency of traject in Jruby, but isn't anymore, so we treat it
-        # extra-special gently in part for legacy reasons.
-        begin
-          require 'traject/marc4j_reader'
-        rescue LoadError => e
-          if e.path == 'traject/marc4j_reader'
-            raise ArgumentError.new("Trying to use 'Traject::Marc4JReader' as reader_class_name, but it is not available. Please install the 'traject-marc4j_reader' gem, or add it to your Gemfile.")
-          else
-            raise e
-          end
-        end
-      end
 
       @reader_class = qualified_const_get(reader_class_name)
     end

--- a/lib/traject/indexer.rb
+++ b/lib/traject/indexer.rb
@@ -19,9 +19,6 @@ require 'traject/macros/transformation'
 
 require 'traject/indexer/marc_indexer'
 
-if defined? JRUBY_VERSION
-  require 'traject/marc4j_reader'
-end
 
 # This class does indexing for traject: Getting input records from a Reader
 # class, mapping the input records to an output hash, and then sending the output

--- a/lib/traject/indexer.rb
+++ b/lib/traject/indexer.rb
@@ -720,7 +720,24 @@ class Traject::Indexer
 
   def reader_class
     unless defined? @reader_class
-      @reader_class = qualified_const_get(settings["reader_class_name"])
+      reader_class_name = settings["reader_class_name"]
+
+      if reader_class_name == "Traject::Marc4JReader"
+        # special handling since this is JRuby MARC default, but is in another gem.
+        # It used to be a dependency of traject in Jruby, but isn't anymore, so we treat it
+        # extra-special gently in part for legacy reasons.
+        begin
+          require 'traject/marc4j_reader'
+        rescue LoadError => e
+          if e.path == 'traject/marc4j_reader'
+            raise ArgumentError.new("Trying to use 'Traject::Marc4JReader' as reader_class_name, but it is not available. Please install the 'traject-marc4j_reader' gem, or add it to your Gemfile.")
+          else
+            raise e
+          end
+        end
+      end
+
+      @reader_class = qualified_const_get(reader_class_name)
     end
     return @reader_class
   end

--- a/lib/traject/indexer/marc_indexer.rb
+++ b/lib/traject/indexer/marc_indexer.rb
@@ -7,15 +7,10 @@ module Traject
 
       def self.default_settings
         @default_settings ||= begin
-          is_jruby = defined?(JRUBY_VERSION)
-
           marc_settings = {
-            "reader_class_name"       => is_jruby ? "Traject::Marc4JReader" : "Traject::MarcReader",
+            "reader_class_name"       => "Traject::MarcReader",
             "marc_source.type"        => "binary",
           }
-          if is_jruby
-            marc_settings["marc4j_reader.permissive"] = true
-          end
           super.merge(marc_settings)
         end
       end

--- a/test/indexer/settings_test.rb
+++ b/test/indexer/settings_test.rb
@@ -127,30 +127,6 @@ describe "Traject::Indexer#settings" do
     end
   end
 
-  describe "JRuby / MRI" do
-    before do
-      @indexer = Traject::Indexer::MarcIndexer.new
-    end
-
-    it "has the right indexer name" do
-      if defined? JRUBY_VERSION
-        assert_equal "Traject::Marc4JReader", @indexer.settings['reader_class_name']
-      else
-        assert_equal "Traject::MarcReader", @indexer.settings['reader_class_name']
-      end
-    end
-
-    # This next one has the added effect of making sure the correct class
-    # has actually been loaded -- otherwise the constant wouldn't be available
-    it "has the correct default reader class based on platform" do
-      if defined? JRUBY_VERSION
-        assert_equal "Traject::Marc4JReader", @indexer.reader_class.name
-      else
-        assert_equal "Traject::MarcReader", @indexer.reader_class.name
-      end
-    end
-  end
-
   describe "order of precedence" do
     it "args beat 'provides'" do
       # args come from command-line in typical use

--- a/test/indexer/settings_test.rb
+++ b/test/indexer/settings_test.rb
@@ -142,11 +142,11 @@ describe "Traject::Indexer#settings" do
 
     # This next one has the added effect of making sure the correct class
     # has actually been loaded -- otherwise the constant wouldn't be available
-    it "has the correct default indexer class based on platform" do
+    it "has the correct default reader class based on platform" do
       if defined? JRUBY_VERSION
-        assert_equal Traject::Marc4JReader, @indexer.reader_class
+        assert_equal "Traject::Marc4JReader", @indexer.reader_class.name
       else
-        assert_equal Traject::MarcReader, @indexer.reader_class
+        assert_equal "Traject::MarcReader", @indexer.reader_class.name
       end
     end
   end

--- a/traject.gemspec
+++ b/traject.gemspec
@@ -32,16 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'marc-fastxmlwriter', '~>1.0' # fast marc->xml
   spec.add_dependency "nokogiri", "~> 1.0" # NokogiriIndexer
 
-  # If we're building the package under JRuby, add in the
-  # jruby-only gems and specify the platform.
-
-  if defined? JRUBY_VERSION
-    spec.platform = 'java'
-    spec.add_dependency "traject-marc4j_reader", "~> 1.0"
-  else
-    spec.platform = "ruby"
-  end
-
   spec.add_development_dependency "bundler", '~> 1.7'
 
   spec.add_development_dependency "rake"


### PR DESCRIPTION
closes #185 

In past (pre 3.0) traject, there was a separate JRuby version of traject released to rubygems. 

It was identical to MRI except for having a dependency on the gem [traject-marc4j_reader](https://github.com/traject/traject-marc4j_reader), which contains the `Traject::Marc4JReader` which was (and remains) the default reader for MARC in JRuby. 

One problem is this required maintainers to remember to do both the JRuby and MRI releases every time they released the gem, which was annoying and easy to forget to do. 

This PR removes the separate JRuby release, *and* no longer has special JRuby-specific defaults to Marc4J-based MARC reader.  

Marc4J reader still recommended, @billdueber's past investigations suggest it can give you from 3x to 10x performance improvement. 

~However, the `Traject::Marc4JReader` is still the default reader for MARC in JRuby.~

~Since the `traject-marc4j_reader` is no longer actually a dependency, developers will need to install it manually. Either:~

~    $ gem install traject-marc4j_reader~

~Or if using bundler, just add `gem 'traject-marc4j_reader', "~> 1.0"` to your `Gemfile`. ~

~If you try to use Traject under Jruby with MARC, and it tries to use the default `Traject::Marc4JReader`, and can't find it, you'll get a custom crafted and hopefully clear error message:~

~> ArgumentError: Trying to use 'Traject::Marc4JReader' as reader_class_name, but it is not available. Please install the 'traject-marc4j_reader' gem, or add it to your Gemfile.~

~Hopefully if you get that and google, you'll find this PR!~