### PR TITLE
Appropriately log ruby 2.1+ exception.cause

### DIFF
--- a/lib/traject/command_line.rb
+++ b/lib/traject/command_line.rb
@@ -84,7 +84,7 @@ module Traject
       return result
     rescue Exception => e
       # Try to log unexpected exceptions if possible
-      indexer && indexer.logger && indexer.logger.fatal("Traject::CommandLine: Unexpected exception, terminating execution: #{e.inspect}") rescue nil
+      indexer && indexer.logger && indexer.logger.fatal("Traject::CommandLine: Unexpected exception, terminating execution: #{Traject::Util.exception_to_log_message(e)}") rescue nil
       raise e
     end
 

--- a/lib/traject/util.rb
+++ b/lib/traject/util.rb
@@ -8,8 +8,15 @@ module Traject
       msg = indent + "Exception: " + e.class.name + ": " + e.message + "\n"
       msg += indent + e.backtrace.first + "\n"
 
-      if (e.respond_to?(:getRootCause) && e.getRootCause && e != e.getRootCause)
+      caused_by = e.cause
+      # JRuby Java exception might have getRootCause
+      if caused_by == nil && e.respond_to?(:getRootCause) && e.getRootCause
         caused_by = e.getRootCause
+      end
+      if caused_by == e
+        caused_by = nil
+      end
+      if caused_by
         msg       += indent + "Caused by\n"
         msg       += indent + caused_by.class.name + ": " + caused_by.message + "\n"
         msg       += indent + caused_by.backtrace.first + "\n"


### PR DESCRIPTION
Leaving in the weird logic for getRootCause, which we sometimes have in JRuby, as a fallback.

Also have top-level commandline rescue use existing exception logging logic. 