### PR TITLE
Fix method name typo in indexer batch logging

### DIFF
--- a/lib/traject/indexer.rb
+++ b/lib/traject/indexer.rb
@@ -539,10 +539,11 @@ class Traject::Indexer
             :logger        => logger
         )
 
+
         if log_batch_size && (count % log_batch_size == 0)
           batch_rps   = log_batch_size / (Time.now - batch_start_time)
           overall_rps = count / (Time.now - start_time)
-          logger.send(settings["log.batch_size.severity"].downcase.to_sym, "Traject::Indexer#process, read #{count} records at: #{context.source_inspect}; #{'%.0f' % batch_rps}/s this batch, #{'%.0f' % overall_rps}/s overall")
+          logger.send(settings["log.batch_size.severity"].downcase.to_sym, "Traject::Indexer#process, read #{count} records at: #{context.record_inspect}; #{'%.0f' % batch_rps}/s this batch, #{'%.0f' % overall_rps}/s overall")
           batch_start_time = Time.now
         end
 

--- a/test/indexer/read_write_test.rb
+++ b/test/indexer/read_write_test.rb
@@ -152,4 +152,27 @@ describe "Traject::Indexer#process" do
       assert output_hashes.all? { |hash| hash["title"].length > 0 }
     end
   end
+
+  describe "setting log.batch_size" do
+    before do
+      @indexer = Traject::Indexer::MarcIndexer.new(
+        "writer_class_name" => "Traject::NullWriter",
+        "log.batch_size" => 1,
+      ) do
+        to_field "title", extract_marc("245")
+      end
+
+      @log_output = StringIO.new
+      logger = Logger.new(@log_output)
+      @indexer.logger = logger
+
+      @file = File.open(support_file_path "test_data.utf8.mrc")
+    end
+
+    it "outputs batch completion to log" do
+      @indexer.process(@file)
+
+      assert_includes @log_output.string, "Traject::Indexer#process, read 1 records at"
+    end
+  end
 end


### PR DESCRIPTION
Bug found by @banukutlu, thanks!

Now with test that would have caught bug, and generally tests indexer batch logging.