### PR TITLE
Drop support for MRI 2.3, require 2.4+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,14 @@ cache: bundler
 # at downloading jruby, and
 sudo: true
 rvm:
-  - 2.3.6
-  - 2.4.3
+  - 2.4.4
   - 2.5.1
   - "2.6.0-preview2"
 # avoid having travis install jdk on MRI builds where we don't need it.
 matrix:
   include:
     - jdk: openjdk8
-      rvm: jruby-9.0.5.0
+      rvm: jruby-9.1.17.0
     - jdk: openjdk8
       rvm: jruby-9.2.0.0
   allow_failures:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Initially by Jonathan Rochkind (Johns Hopkins Libraries) and Bill Dueber (Univer
 
 ## Installation
 
-Traject runs under jruby (9.0.x or higher), MRI ruby (2.3.x or higher), or probably any other ruby platform.
+Traject runs under jruby (9.1.x or higher), MRI ruby (2.3.x or higher), or probably any other ruby platform.
 
 Once you have ruby installed, just `$ gem install traject`.
 


### PR DESCRIPTION
Also means drop JRuby 9.0.0, require 9.1.0+