### PR TITLE
Don't close STDOUT when not a tty.

### DIFF
--- a/lib/traject/line_writer.rb
+++ b/lib/traject/line_writer.rb
@@ -57,7 +57,7 @@ class Traject::LineWriter
   end
 
   def close
-    @output_file.close unless (@output_file.nil? || @output_file.tty?)
+    @output_file.close unless @output_file.nil? || @output_file.tty? || @output_file == $stdout
   end
 
 end


### PR DESCRIPTION
In cases in which STDOUT is not a tty (e.g., when piped), LineWriter will close STDOUT. This causes subsequent uses of the LineWriter to report `closed stream (IOError)`.

Refs https://github.com/sul-dlss/dlme-transform/issues/54