### PR TITLE
Fix Nokogiri reader for Jruby nokogiri >= 1.9.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## NEXT
+
+* Nokogiri dependency for the NokogiriReader increased to `~> 1.9`. When using Jruby `each_record_xpath`, resulting yielded documents may have xmlns declarations on different nodes than in MRI (and previous versions of nokogiri), but we could find now way around this with nokogiri >= 1.9.0. The documents should still be semantically equivalent for namespace use.
+
 ## 3.0.0
 
 ### Changed/Backwards Incompatibilities

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## NEXT
 
-* Nokogiri dependency for the NokogiriReader increased to `~> 1.9`. When using Jruby `each_record_xpath`, resulting yielded documents may have xmlns declarations on different nodes than in MRI (and previous versions of nokogiri), but we could find now way around this with nokogiri >= 1.9.0. The documents should still be semantically equivalent for namespace use.
+* Nokogiri dependency for the NokogiriReader increased to `~> 1.9`. When using Jruby `each_record_xpath`, resulting yielded documents may have xmlns declarations on different nodes than in MRI (and previous versions of nokogiri), but we could find now way around this with nokogiri >= 1.9.0. The documents should still be semantically equivalent for namespace use. https://github.com/traject/traject/pull/209
 
 ## 3.0.0
 

--- a/doc/xml.md
+++ b/doc/xml.md
@@ -133,6 +133,8 @@ The NokogiriReader parser should be relatively performant though, allowing you t
 
 (There is a half-finished `ExperimentalStreamingNokogiriReader` available, but it is experimental, half-finished, may disappear or change in backwards compat at any time, problematic, not recommended for production use, etc.)
 
+Note also that in Jruby, when using `each_record_xpath` with the NokogiriReader, the extracted individual documents may have xmlns declerations in different places than you may expect, although they will still be semantically equivalent for namespace processing. This is due to Nokogiri JRuby implementation, and we could find no good way to ensure consistent behavior with MRI. See: https://github.com/sparklemotion/nokogiri/issues/1875
+
 ### Jruby
 
 It may be that nokogiri JRuby is just much slower than nokogiri MRI (at least when namespaces are involved?)  It may be that our workaround to a [JRuby bug involving namespaces on moving nodes](https://github.com/sparklemotion/nokogiri/issues/1774) doesn't help.

--- a/test/nokogiri_reader_test.rb
+++ b/test/nokogiri_reader_test.rb
@@ -139,7 +139,15 @@ describe "Traject::NokogiriReader" do
 
     assert_length manually_extracted.size, yielded_records
     assert yielded_records.all? {|r| r.kind_of? Nokogiri::XML::Document }
-    assert_equal manually_extracted.collect(&:to_xml), yielded_records.collect(&:root).collect(&:to_xml)
+
+    expected_xml = manually_extracted.collect(&:to_xml)
+    actual_xml   = yielded_records.collect(&:root).collect(&:to_xml)
+
+    expected_xml.size.times do |i|
+      assert_equal expected_xml[i-1], actual_xml[i-1]
+    end
+
+    #assert_equal manually_extracted.collect(&:to_xml), yielded_records.collect(&:root).collect(&:to_xml)
   end
 
   describe "without each_record_xpath" do

--- a/traject.gemspec
+++ b/traject.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "httpclient", "~> 2.5"
   spec.add_dependency "http", "~> 3.0" # used in oai_pmh_reader, may use more extensively in future instead of httpclient
   spec.add_dependency 'marc-fastxmlwriter', '~>1.0' # fast marc->xml
-  spec.add_dependency "nokogiri", "~> 1.0" # NokogiriIndexer
+  spec.add_dependency "nokogiri", "~> 1.9" # NokogiriIndexer
 
   spec.add_development_dependency "bundler", '~> 1.7'
 


### PR DESCRIPTION
Closes #203 

How nokogiri did namespaces changed. Our previous workarounds to Jruby nokogiri namespace issues no longer worked in Jruby nokogiri 1.9.0+. 

In jruby nokogiri 1.9.0+, without workarounds, when using each_record_xpath with NokogiriReader, you may find that xmlns declerations aren't on the elements you expected in the individual extracted XML documents. They aren't on the elements they were previously, or the ones in MRI. We could find no way to solve this in nokogiri 1.9.0+ -- but despite the declerations not being where expected, the documents should be semantically equivalent as far as XML namespaces go. 

See: https://github.com/sparklemotion/nokogiri/issues/1875

Traject now requires nokogiri ~> 1.9, it was too hard to support both. 

On the plus side, removing the previous workarounds should make NokogiriReader each_record_xpath somewhat more performant on JRuby.