### PR TITLE
Update tested ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,13 @@ sudo: true
 rvm:
   - 2.4.4
   - 2.5.1
-  - "2.6.0-preview2"
+  - 2.6.1
 # avoid having travis install jdk on MRI builds where we don't need it.
 matrix:
   include:
     - jdk: openjdk8
       rvm: jruby-9.1.17.0
     - jdk: openjdk8
-      rvm: jruby-9.2.0.0
+      rvm: jruby-9.2.6.0
   allow_failures:
-    - rvm: "2.6.0-preview2"
+    - rvm: 2.6.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,3 @@ matrix:
       rvm: jruby-9.1.17.0
     - jdk: openjdk8
       rvm: jruby-9.2.6.0
-  allow_failures:
-    - rvm: 2.6.1


### PR DESCRIPTION
jcoyne's PR, rebased on master so it will pass. Closes #205

Plus, do NOT allow failure on 2.6.1, now that 2.6.x is in a full release (not pre-release), we don't want to allow failure in CI. 