### PR TITLE
SolrJsonWriter gets settings to control commit semantics

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@
 
 * SolrJsonWriter has a `delete(solr-unique-key)` method. Does not currently use any batching or threading. https://github.com/traject/traject/pull/214
 
+* SolrJsonWriter has new settings to control commit semantics. `solr_writer.solr_update_args` and `solr_writer.commit_solr_update_args`, both have hash values that are Solr update handler query params. https://github.com/traject/traject/pull/215
+
+
 
 ## 3.0.0
 

--- a/test/solr_json_writer_test.rb
+++ b/test/solr_json_writer_test.rb
@@ -170,15 +170,25 @@ describe "Traject::SolrJsonWriter" do
     assert_length 1, @fake_http_client.post_args, "Has flushed to solr"
   end
 
-  it "commits on close when set" do
-    @writer = create_writer("solr.url" => "http://example.com", "solr_writer.commit_on_close" => "true")
-    @writer.put context_with({"id" => "one", "key" => ["value1", "value2"]})
-    @writer.close
+  describe "commit" do
+    it "commits on close when set" do
+      @writer = create_writer("solr.url" => "http://example.com", "solr_writer.commit_on_close" => "true")
+      @writer.put context_with({"id" => "one", "key" => ["value1", "value2"]})
+      @writer.close
 
-    last_solr_get = @fake_http_client.get_args.last
+      last_solr_get = @fake_http_client.get_args.last
 
-    assert_equal "http://example.com/update/json", last_solr_get[0]
-    assert_equal( {"commit" => "true"}, last_solr_get[1] )
+      assert_equal "http://example.com/update/json", last_solr_get[0]
+      assert_equal( {"commit" => "true"}, last_solr_get[1] )
+    end
+
+    it "can manually send commit" do
+      @writer = create_writer("solr.url" => "http://example.com")
+      @writer.commit
+      last_solr_get = @fake_http_client.get_args.last
+      assert_equal "http://example.com/update/json", last_solr_get[0]
+      assert_equal( {"commit" => "true"}, last_solr_get[1] )
+    end
   end
 
   describe "solr_writer.solr_update_args" do

--- a/test/solr_json_writer_test.rb
+++ b/test/solr_json_writer_test.rb
@@ -161,6 +161,34 @@ describe "Traject::SolrJsonWriter" do
     assert_equal( {"commit" => "true"}, last_solr_get[1] )
   end
 
+  describe "solr_writer.solr_update_args" do
+    before do
+      @writer = create_writer("solr_writer.solr_update_args" => { softCommit: true } )
+    end
+
+    it "sends update args" do
+      @writer.put context_with({"id" => "one", "key" => ["value1", "value2"]})
+      @writer.close
+
+      assert_equal 1, @fake_http_client.post_args.count
+
+      post_args = @fake_http_client.post_args.first
+
+      assert_equal "http://example.com/solr/update/json?softCommit=true", post_args[0]
+    end
+
+    it "sends update args with delete" do
+      @writer.delete("test-id")
+      @writer.close
+
+      assert_equal 1, @fake_http_client.post_args.count
+
+      post_args = @fake_http_client.post_args.first
+
+      assert_equal "http://example.com/solr/update/json?softCommit=true", post_args[0]
+    end
+  end
+
   describe "skipped records" do
     it "skips and reports under max_skipped" do
       strio = StringIO.new

--- a/test/solr_json_writer_test.rb
+++ b/test/solr_json_writer_test.rb
@@ -181,6 +181,20 @@ describe "Traject::SolrJsonWriter" do
       assert_equal "http://example.com/update/json?commit=true", last_solr_get[0]
     end
 
+    it "commits on close with commit_solr_update_args" do
+      @writer = create_writer(
+        "solr.url" => "http://example.com",
+        "solr_writer.commit_on_close" => "true",
+        "solr_writer.commit_solr_update_args" => { softCommit: true }
+      )
+      @writer.put context_with({"id" => "one", "key" => ["value1", "value2"]})
+      @writer.close
+
+      last_solr_get = @fake_http_client.get_args.last
+
+      assert_equal "http://example.com/update/json?softCommit=true", last_solr_get[0]
+    end
+
     it "can manually send commit" do
       @writer = create_writer("solr.url" => "http://example.com")
       @writer.commit
@@ -194,6 +208,28 @@ describe "Traject::SolrJsonWriter" do
       @writer.commit(softCommit: true, optimize: true, waitFlush: false)
       last_solr_get = @fake_http_client.get_args.last
       assert_equal "http://example.com/update/json?softCommit=true&optimize=true&waitFlush=false", last_solr_get[0]
+    end
+
+    it "uses commit_solr_update_args settings by default" do
+      @writer = create_writer(
+        "solr.url" => "http://example.com",
+        "solr_writer.commit_solr_update_args" => { softCommit: true }
+      )
+      @writer.commit
+
+      last_solr_get = @fake_http_client.get_args.last
+      assert_equal "http://example.com/update/json?softCommit=true", last_solr_get[0]
+    end
+
+    it "overrides commit_solr_update_args with method arg" do
+      @writer = create_writer(
+        "solr.url" => "http://example.com",
+        "solr_writer.commit_solr_update_args" => { softCommit: true, foo: "bar" }
+      )
+      @writer.commit(commit: true)
+
+      last_solr_get = @fake_http_client.get_args.last
+      assert_equal "http://example.com/update/json?commit=true", last_solr_get[0]
     end
   end
 

--- a/test/solr_json_writer_test.rb
+++ b/test/solr_json_writer_test.rb
@@ -178,16 +178,22 @@ describe "Traject::SolrJsonWriter" do
 
       last_solr_get = @fake_http_client.get_args.last
 
-      assert_equal "http://example.com/update/json", last_solr_get[0]
-      assert_equal( {"commit" => "true"}, last_solr_get[1] )
+      assert_equal "http://example.com/update/json?commit=true", last_solr_get[0]
     end
 
     it "can manually send commit" do
       @writer = create_writer("solr.url" => "http://example.com")
       @writer.commit
+
       last_solr_get = @fake_http_client.get_args.last
-      assert_equal "http://example.com/update/json", last_solr_get[0]
-      assert_equal( {"commit" => "true"}, last_solr_get[1] )
+      assert_equal "http://example.com/update/json?commit=true", last_solr_get[0]
+    end
+
+    it "can manually send commit with specified args" do
+      @writer = create_writer("solr.url" => "http://example.com")
+      @writer.commit(softCommit: true, optimize: true, waitFlush: false)
+      last_solr_get = @fake_http_client.get_args.last
+      assert_equal "http://example.com/update/json?softCommit=true&optimize=true&waitFlush=false", last_solr_get[0]
     end
   end
 


### PR DESCRIPTION
* solr_writer.solr_update_args can be used to have every update do a commit/softCommit/whatever
* solr_writer.commit_solr_update_args can be used to change commits to softCommits
* When calling #commit manually, can also use a hash to force softCommit or what have you