### PR TITLE
SolrJsonWriter::MaxSkippedRecordsExceeded will now have a #cause

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@
 
 * SolrJsonWriter has new settings to control commit semantics. `solr_writer.solr_update_args` and `solr_writer.commit_solr_update_args`, both have hash values that are Solr update handler query params. https://github.com/traject/traject/pull/215
 
+* SolrJsonWriter error handling/reporting
+  * when MaxSkippedRecordsExceeded is raised, it will have a #cause that is the last error, which resulted in MaxSkippedRecordsExceeded. Some error reporting systems, including Rails, will automatically log #cause, so that's helpful. https://github.com/traject/traject/pull/216
 
 
 ## 3.0.0


### PR DESCRIPTION
that is the last error encountered that triggered max skipped records. (if max skipped records is 0, as per default, it's the only error)

We have to raise in a rescue to get ruby 2.1+ behavior where thing we rescued is available in #cause, and will be printed by for instance some standard Rails exception printers.

For HTTP response errors, that previously counted as skippable and still do, we have a new error class, Traject::SolrJsonWriter::BadHttpResponse