### PR TITLE
Can pass a Logger-compat instance in settings[logger]

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 
 * LineWriter guesses better about when to auto-close, and provides an optional explicit setting in case it guesses wrong. https://github.com/traject/traject/pull/211
 
-* Class-level indexer configuration, for custom indexer subclasses, now available with class-level `configure` method. https://github.com/traject/traject/pull/213
+* Class-level indexer configuration, for custom indexer subclasses, now available with class-level `configure` method. Warning, Indexers are still expensive to instantiate though. https://github.com/traject/traject/pull/213
 
 * SolrJsonWriter has a `delete(solr-unique-key)` method. Does not currently use any batching or threading. https://github.com/traject/traject/pull/214
 
@@ -15,6 +15,7 @@
 * SolrJsonWriter error handling/reporting
   * when MaxSkippedRecordsExceeded is raised, it will have a #cause that is the last error, which resulted in MaxSkippedRecordsExceeded. Some error reporting systems, including Rails, will automatically log #cause, so that's helpful. https://github.com/traject/traject/pull/216
 
+* Traject::Indexer will now use a Logger(-compatible) instance passed in in setting 'logger' https://github.com/traject/traject/pull/217
 
 ## 3.0.0
 

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -119,6 +119,8 @@ settings are applied first of all. It's recommended you use `provide`.
 
 * `log.batch_size.severity`: If `log.batch_size` is set, what logger severity level to log to. Default "INFO", set to "DEBUG" etc if desired.
 
+* 'logger': Ignore all the other logger settings, just pass a `Logger` compatible logger instance in directly.
+
 
 
 

--- a/lib/traject/indexer.rb
+++ b/lib/traject/indexer.rb
@@ -370,6 +370,10 @@ class Traject::Indexer
 
   # Create logger according to settings
   def create_logger
+    if settings["logger"]
+      # none of the other settings matter, we just got a logger
+      return settings["logger"]
+    end
 
     logger_level  = settings["log.level"] || "info"
 

--- a/test/indexer/error_handler_test.rb
+++ b/test/indexer/error_handler_test.rb
@@ -56,4 +56,22 @@ describe 'Custom mapping error handler' do
 
     assert_nil indexer.map_record({})
   end
+
+  it "uses logger from settings" do
+    desired_logger = Logger.new("/dev/null")
+    set_logger = nil
+    indexer.configure do
+      settings do
+        provide "logger", desired_logger
+        provide "mapping_rescue", -> (ctx, e) {
+          set_logger = ctx.logger
+        }
+      end
+      to_field 'id' do |_context , _exception|
+        raise 'this was always going to fail'
+      end
+    end
+    indexer.map_record({})
+    assert_equal desired_logger.object_id, set_logger.object_id
+  end
 end


### PR DESCRIPTION
All other logger settings will be ignored. Useful for programmatic use. Perhaps you want to set to 'Rails.logger'