### PR TITLE
SolrJsonWriter params to commit should override commit_solr_update_args, not be merged in

### DIFF
--- a/lib/traject/solr_json_writer.rb
+++ b/lib/traject/solr_json_writer.rb
@@ -159,10 +159,11 @@ class Traject::SolrJsonWriter
     send_batch( Traject::Util.drain_queue(@batched_queue) )
   end
 
-  # configured update url, with settings @solr_update_args added to it
-  def solr_update_url_with_query(query_params = nil)
-    if query_params && ! query_params.empty?
-      @solr_update_url + '?' + URI.encode_www_form((@solr_update_args || {}).merge(query_params))
+  # configured update url, with either settings @solr_update_args or passed in
+  # query_params added to it
+  def solr_update_url_with_query(query_params)
+    if query_params
+      @solr_update_url + '?' + URI.encode_www_form(query_params)
     else
       @solr_update_url
     end

--- a/test/solr_json_writer_test.rb
+++ b/test/solr_json_writer_test.rb
@@ -204,10 +204,10 @@ describe "Traject::SolrJsonWriter" do
     end
 
     it "can manually send commit with specified args" do
-      @writer = create_writer("solr.url" => "http://example.com")
-      @writer.commit(softCommit: true, optimize: true, waitFlush: false)
+      @writer = create_writer("solr.url" => "http://example.com", "solr_writer.commit_solr_update_args" => { softCommit: true })
+      @writer.commit(commit: true, optimize: true, waitFlush: false)
       last_solr_get = @fake_http_client.get_args.last
-      assert_equal "http://example.com/update/json?softCommit=true&optimize=true&waitFlush=false", last_solr_get[0]
+      assert_equal "http://example.com/update/json?commit=true&optimize=true&waitFlush=false", last_solr_get[0]
     end
 
     it "uses commit_solr_update_args settings by default" do


### PR DESCRIPTION
Was always intended this way, solr_update_url_with_query had old implementation not intended.

Corrects #215