### PR TITLE
SolrJsonWriter has setting solr_writer.http_timeout

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@
 
 * Traject::Indexer will now use a Logger(-compatible) instance passed in in setting 'logger' https://github.com/traject/traject/pull/217
 
+* SolrJsonWriter now respects a `solr_writer.http_timeout` setting, in seconds, to be passed to HTTPClient instance. https://github.com/traject/traject/pull/219
+
 ## 3.0.0
 
 ### Changed/Backwards Incompatibilities


### PR DESCRIPTION
For CLI batch processing, the default long HTTPClient timeouts are fine.

But for programmatic use, they are really too long. (60-120 seconds).

Provide a setting to set timeout. For right now, one timeout value can be supplied that can be set as equal send/receive/connect timeouts on HTTPClient. Maybe later we need separate ones, but keep it simple for now.

There are no tests cause couldn't figure out a good way to do them, oh well for now.