### PR TITLE
Extract a Context#add_output method

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 ## NEXT
 
+* Context#add_output is added, convenient for custom ruby code.
+      each_record do |record, context|
+         context.add_output "key", something_from(record)
+      end
+  https://github.com/traject/traject/pull/220
+
 * Nokogiri dependency for the NokogiriReader increased to `~> 1.9`. When using Jruby `each_record_xpath`, resulting yielded documents may have xmlns declarations on different nodes than in MRI (and previous versions of nokogiri), but we could find now way around this with nokogiri >= 1.9.0. The documents should still be semantically equivalent for namespace use. https://github.com/traject/traject/pull/209
 
 * LineWriter guesses better about when to auto-close, and provides an optional explicit setting in case it guesses wrong. https://github.com/traject/traject/pull/211

--- a/README.md
+++ b/README.md
@@ -311,11 +311,14 @@ like `to_field`, is executed for every record, but without being tied
 to a specific output field.
 
 `each_record` can be used for logging or notifiying, computing intermediate
-results, or writing to more than one field at once.
+results, or more complex ruby logic.
 
 ~~~ruby
   each_record do |record|
     some_custom_logging(record)
+  end
+  each_record do |record, context|
+    context.add_output(:some_value, extract_some_value_from_record(record))
   end
 ~~~
 

--- a/doc/indexing_rules.md
+++ b/doc/indexing_rules.md
@@ -247,13 +247,12 @@ each_record do |record, context|
 end
 
 each_record do |record, context|
-  (val1, val2) = calculate_two_things_from(record)
+  if eligible_for_things?(record)
+    (val1, val2) = calculate_two_things_from(record)
 
-  context.output_hash["first_field"] ||= []
-  context.output_hash["first_field"] << val1
-
-  context.output_hash["second_field"] ||= []
-  context.output_hash["second_field"] << val2
+    context.add_output("first_field", val1)
+    context.add_output("second_field", val2)
+  end
 end
 ~~~
 

--- a/lib/traject/indexer.rb
+++ b/lib/traject/indexer.rb
@@ -283,10 +283,9 @@ class Traject::Indexer
         "log.batch_size.severity" => "info",
 
         # how to post-process the accumulator
-        "allow_nil_values"        => false,
-        "allow_duplicate_values"  => true,
-
-        "allow_empty_fields"      => false
+        Traject::Indexer::ToFieldStep::ALLOW_NIL_VALUES => false,
+        Traject::Indexer::ToFieldStep::ALLOW_DUPLICATE_VALUES  => true,
+        Traject::Indexer::ToFieldStep::ALLOW_EMPTY_FIELDS => false
     }.freeze
   end
 

--- a/lib/traject/indexer/context.rb
+++ b/lib/traject/indexer/context.rb
@@ -82,7 +82,7 @@ class Traject::Indexer
       str
     end
 
-    # Add values to an array in context.output_hash with the specified key/field_name
+    # Add values to an array in context.output_hash with the specified key/field_name(s)
     #
     # * creates array in output_hash if currently nil.
     # * uniqs accumulator, unless settings["allow_dupicate_values"] is set.
@@ -92,16 +92,23 @@ class Traject::Indexer
     #
     # @example add one value
     #   context.add_output(:additional_title, "a title")
+    #
     # @example add multiple values as multiple params
     #   context.add_output("additional_title", "a title", "another title")
+    #
     # @example add multiple values as multiple params from array using ruby spread operator
     #   context.add_output(:some_key, *array_of_values)
     #
+    # @example add to multiple keys in output hash
+    #   context.add_output(["key1", "key2"], "value")
+    #
     # @return [Traject::Context] self
-    def add_output(key, *values)
-      accumulator = (self.output_hash[key.to_s] ||= [])
-      accumulator.concat values
-      accumulator.uniq! unless self.settings && self.settings[Traject::Indexer::ToFieldStep::ALLOW_DUPLICATE_VALUES]
+    def add_output(field_name, *values)
+      Array(field_name).each do |key|
+        accumulator = (self.output_hash[key.to_s] ||= [])
+        accumulator.concat values
+        accumulator.uniq! unless self.settings && self.settings[Traject::Indexer::ToFieldStep::ALLOW_DUPLICATE_VALUES]
+      end
 
       return self
     end

--- a/lib/traject/indexer/context.rb
+++ b/lib/traject/indexer/context.rb
@@ -82,6 +82,29 @@ class Traject::Indexer
       str
     end
 
+    # Add values to an array in context.output_hash with the specified key/field_name
+    #
+    # * creates array in output_hash if currently nil.
+    # * uniqs accumulator, unless settings["allow_dupicate_values"] is set.
+    #
+    # Multiple values can be added with multiple arguments (we avoid an array argument meaning
+    # multiple values to accomodate odd use cases where array itself is desired in output_hash value)
+    #
+    # @example add one value
+    #   context.add_output(:additional_title, "a title")
+    # @example add multiple values as multiple params
+    #   context.add_output("additional_title", "a title", "another title")
+    # @example add multiple values as multiple params from array using ruby spread operator
+    #   context.add_output(:some_key, *array_of_values)
+    #
+    # @return [Traject::Context] self
+    def add_output(key, *values)
+      accumulator = (self.output_hash[key.to_s] ||= [])
+      accumulator.concat values
+      accumulator.uniq! unless self.settings && self.settings[Traject::Indexer::ToFieldStep::ALLOW_DUPLICATE_VALUES]
+
+      return self
+    end
   end
 
 

--- a/lib/traject/indexer/step.rb
+++ b/lib/traject/indexer/step.rb
@@ -153,7 +153,7 @@ class Traject::Indexer
     ALLOW_EMPTY_FIELDS     = "allow_empty_fields".freeze
     ALLOW_DUPLICATE_VALUES = "allow_duplicate_values".freeze
 
-    # Add the accumulator to the context with the correct field name
+    # Add the accumulator to the context with the correct field name(s).
     # Do post-processing on the accumulator (remove nil values, allow empty
     # fields, etc)
     def add_accumulator_to_context!(accumulator, context)

--- a/lib/traject/indexer/step.rb
+++ b/lib/traject/indexer/step.rb
@@ -158,10 +158,7 @@ class Traject::Indexer
 
       # field_name can actually be an array of field names
       Array(field_name).each do |a_field_name|
-        context.output_hash[a_field_name] ||= []
-
-        existing_accumulator = context.output_hash[a_field_name].concat(accumulator)
-        existing_accumulator.uniq! unless context.settings[ALLOW_DUPLICATE_VALUES]
+        context.add_output(a_field_name, *accumulator)
       end
     end
   end

--- a/lib/traject/indexer/step.rb
+++ b/lib/traject/indexer/step.rb
@@ -157,9 +157,7 @@ class Traject::Indexer
       return if accumulator.empty? and not (context.settings[ALLOW_EMPTY_FIELDS])
 
       # field_name can actually be an array of field names
-      Array(field_name).each do |a_field_name|
-        context.add_output(a_field_name, *accumulator)
-      end
+      context.add_output(field_name, *accumulator)
     end
   end
 

--- a/lib/traject/indexer/step.rb
+++ b/lib/traject/indexer/step.rb
@@ -145,17 +145,18 @@ class Traject::Indexer
       return accumulator
     end
 
-    # Add the accumulator to the context with the correct field name
-    # Do post-processing on the accumulator (remove nil values, allow empty
-    # fields, etc)
+
+    # These constqnts here for historical/legacy reasons, they really oughta
+    # live in Traject::Context, but in case anyone is referring to them
+    # we'll leave them here for now.
     ALLOW_NIL_VALUES       = "allow_nil_values".freeze
     ALLOW_EMPTY_FIELDS     = "allow_empty_fields".freeze
     ALLOW_DUPLICATE_VALUES = "allow_duplicate_values".freeze
 
+    # Add the accumulator to the context with the correct field name
+    # Do post-processing on the accumulator (remove nil values, allow empty
+    # fields, etc)
     def add_accumulator_to_context!(accumulator, context)
-      accumulator.compact! unless context.settings[ALLOW_NIL_VALUES]
-      return if accumulator.empty? and not (context.settings[ALLOW_EMPTY_FIELDS])
-
       # field_name can actually be an array of field names
       context.add_output(field_name, *accumulator)
     end

--- a/test/indexer/context_test.rb
+++ b/test/indexer/context_test.rb
@@ -73,5 +73,10 @@ describe "Traject::Indexer::Context" do
       @context.add_output(:key, "value1")
       assert_equal @context.output_hash, { "key" => ["value1", "value1"] }
     end
+
+    it "can add to multiple fields" do
+      @context.add_output(["field1", "field2"], "value1", "value2")
+      assert_equal @context.output_hash, { "field1" => ["value1", "value2"], "field2" => ["value1", "value2"] }
+    end
   end
 end

--- a/test/indexer/context_test.rb
+++ b/test/indexer/context_test.rb
@@ -38,8 +38,40 @@ describe "Traject::Indexer::Context" do
 
       assert_equal "<record ##{@position} (#{@input_name} ##{@position_in_input}), source_id:#{@record_001} output_id:output_id>", @context.record_inspect
     end
-
   end
 
+  describe "#add_output" do
+    before do
+      @context = Traject::Indexer::Context.new
+    end
+    it "adds one value to nil" do
+      @context.add_output(:key, "value")
+      assert_equal @context.output_hash, { "key" => ["value"] }
+    end
 
+    it "adds multiple values to nil" do
+      @context.add_output(:key, "value1", "value2")
+      assert_equal @context.output_hash, { "key" => ["value1", "value2"] }
+    end
+
+    it "adds one value to existing accumulator" do
+      @context.output_hash["key"] = ["value1"]
+      @context.add_output(:key, "value2")
+      assert_equal @context.output_hash, { "key" => ["value1", "value2"] }
+    end
+
+    it "uniqs by default" do
+      @context.output_hash["key"] = ["value1"]
+      @context.add_output(:key, "value1")
+      assert_equal @context.output_hash, { "key" => ["value1"] }
+    end
+
+    it "does not unique if allow_duplicate_values" do
+      @context.settings = { Traject::Indexer::ToFieldStep::ALLOW_DUPLICATE_VALUES => true }
+      @context.output_hash["key"] = ["value1"]
+
+      @context.add_output(:key, "value1")
+      assert_equal @context.output_hash, { "key" => ["value1", "value1"] }
+    end
+  end
 end

--- a/test/indexer/context_test.rb
+++ b/test/indexer/context_test.rb
@@ -74,6 +74,32 @@ describe "Traject::Indexer::Context" do
       assert_equal @context.output_hash, { "key" => ["value1", "value1"] }
     end
 
+    it "ignores nil values by default" do
+      @context.add_output(:key, "value1", nil, "value2")
+      assert_equal @context.output_hash, { "key" => ["value1", "value2"] }
+    end
+
+    it "allows nil values if allow_nil_values" do
+      @context.settings = { Traject::Indexer::ToFieldStep::ALLOW_NIL_VALUES => true }
+
+      @context.add_output(:key, "value1", nil, "value2")
+      assert_equal @context.output_hash, { "key" => ["value1", nil, "value2"] }
+    end
+
+    it "ignores empty array by default" do
+      @context.add_output(:key)
+      @context.add_output(:key, nil)
+
+      assert_nil @context.output_hash["key"]
+    end
+
+    it "allows empty field if allow_empty_fields" do
+      @context.settings = { Traject::Indexer::ToFieldStep::ALLOW_EMPTY_FIELDS => true }
+
+      @context.add_output(:key, nil)
+      assert_equal @context.output_hash, { "key" => [] }
+    end
+
     it "can add to multiple fields" do
       @context.add_output(["field1", "field2"], "value1", "value2")
       assert_equal @context.output_hash, { "field1" => ["value1", "value2"], "field2" => ["value1", "value2"] }


### PR DESCRIPTION
This logic probably should have been in Context rather than Indexer all along. 

Convenient when doing custom ruby code processing:

```ruby
    each_record do |record, context|
       context.add_output :output_key, complicated_thing_from(record)

       context.add_output(["field1, "field2"], something(record))
    end
```

Should be entirely backwards compat.