### PR TITLE
NokogiriReader has a nokogiri.strict_mode setting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## Next
+
+* NokogiriReader has a "nokogiri.strict_mode" setting. Set to true or string 'true' to ask Nokogori to parse in strict mode, so it will immediately raise on ill-formed XML, instead of nokogiri's default to do what it can with it.
+
 ## 3.1.0
 
 ### Added

--- a/lib/traject/nokogiri_reader.rb
+++ b/lib/traject/nokogiri_reader.rb
@@ -21,6 +21,9 @@ module Traject
   #   If you need to use namespaces here, you need to have them registered with
   #   `nokogiri.default_namespaces`. If your source docs use namespaces, you DO need
   #   to use them in your each_record_xpath.
+  # * nokogiri.strict_mode: if set to `true` or `"true"`, ask Nokogiri to parse in 'strict'
+  #   mode, it will raise a `Nokogiri::XML::SyntaxError` if the XML is not well-formed, instead
+  #   of trying to take it's best-guess correction. https://nokogiri.org/tutorials/ensuring_well_formed_markup.html
   # * nokogiri_reader.extra_xpath_hooks: Experimental in progress, see below.
   #
   # ## nokogiri_reader.extra_xpath_hooks: For handling nodes outside of your each_record_xpath
@@ -87,7 +90,11 @@ module Traject
     end
 
     def each
-      whole_input_doc = Nokogiri::XML.parse(input_stream)
+      config_proc = if settings["nokogiri.strict_mode"]
+        proc { |config| config.strict }
+      end
+
+      whole_input_doc = Nokogiri::XML.parse(input_stream, &config_proc)
 
       if each_record_xpath
         whole_input_doc.xpath(each_record_xpath, default_namespaces).each do |matching_node|

--- a/test/nokogiri_reader_test.rb
+++ b/test/nokogiri_reader_test.rb
@@ -134,6 +134,16 @@ describe "Traject::NokogiriReader" do
     end
   end
 
+  describe "strict_mode" do
+    it "raises on non-well-formed" do
+      # invalid because two sibling root nodes, XML requiers one root node
+      reader = Traject::NokogiriReader.new(StringIO.new("<doc></doc><doc></doc>"), {"nokogiri.strict_mode" => "true" })
+      assert_raises(Nokogiri::XML::SyntaxError) {
+        reader.each { |r| }
+      }
+    end
+  end
+
 
   def shared_tests
     @reader = Traject::NokogiriReader.new(File.open(@xml_sample_path), {


### PR DESCRIPTION
If set to boolean true or string 'true', will ask Nokogiri to parse in strict mode, meaning it will raise an exception if the input XML is not well-formed. By default Nokogiri does it's best to do the best with it it can instead.