### PR TITLE
Add delete_all! method to SolrJsonWriter.

### DIFF
--- a/lib/traject/solr_json_writer.rb
+++ b/lib/traject/solr_json_writer.rb
@@ -270,6 +270,13 @@ class Traject::SolrJsonWriter
     end
   end
 
+  # Send a delete all query.
+  #
+  # This method takes no params and will not automatically commit the deletes.
+  # @example @writer.delete_all!
+  def delete_all!
+    delete(query: "*:*")
+  end
 
   # Get the logger from the settings, or default to an effectively null logger
   def logger

--- a/test/solr_json_writer_test.rb
+++ b/test/solr_json_writer_test.rb
@@ -365,4 +365,13 @@ describe "Traject::SolrJsonWriter" do
       end
     end
   end
+
+  describe "#delete_all!" do
+    it "deletes all" do
+      @writer.delete_all!
+      post_args = @fake_http_client.post_args.first
+      assert_equal "http://example.com/solr/update/json", post_args[0]
+      assert_equal JSON.generate({"delete" => { "query" => "*:*"}}), post_args[1]
+    end
+  end
 end


### PR DESCRIPTION
Often times it's handy to be able to delete all documents in a solr
repository before running a full reindex.

This is a convenience method that allows users to add this step
directly to a traject script.