### PR TITLE
Allow configuring basic auth for solr writer.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 * NokogiriReader has a "nokogiri.strict_mode" setting. Set to true or string 'true' to ask Nokogori to parse in strict mode, so it will immediately raise on ill-formed XML, instead of nokogiri's default to do what it can with it.
 
+* Allow basic auth configuration of the default http client via `solr_writer.basic_auth_user` and `solr_writer.basic_auth_password`.
+
 ## 3.1.0
 
 ### Added

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -93,6 +93,8 @@ settings are applied first of all. It's recommended you use `provide`.
 
 * `solr_writer.thread_pool`: defaults to 1 (single bg thread). A thread pool is used for submitting docs to solr. Set to 0 or nil to disable threading. Set to 1, there will still be a single bg thread doing the adds. May make sense to set higher than number of cores on your indexing machine, as these threads will mostly be waiting on Solr. Speed/capacity of your solr might be more relevant. Note that processing_thread_pool threads can end up submitting to solr too, if solr_json_writer.thread_pool is full.
 
+* `solr_writer.basic_auth_user`, `solr_writer.basic_auth_password`: Not set by default but when both are set the default writer is configured with basic auth.
+
 
 ### Dealing with MARC data
 

--- a/lib/traject/solr_json_writer.rb
+++ b/lib/traject/solr_json_writer.rb
@@ -114,6 +114,12 @@ class Traject::SolrJsonWriter
       if @settings["solr_writer.http_timeout"]
         client.connect_timeout = client.receive_timeout = client.send_timeout = @settings["solr_writer.http_timeout"]
       end
+
+      if @settings["solr_writer.basic_auth_user"] &&
+          @settings["solr_writer.basic_auth_password"]
+        client.set_auth(@settings["solr.url"], @settings["solr_writer.basic_auth_user"], @settings["solr_writer.basic_auth_password"])
+      end
+
       client
     end
 

--- a/test/solr_json_writer_test.rb
+++ b/test/solr_json_writer_test.rb
@@ -170,6 +170,27 @@ describe "Traject::SolrJsonWriter" do
     assert_length 1, @fake_http_client.post_args, "Has flushed to solr"
   end
 
+  it "defaults to not setting basic authentication" do
+    settings = { "solr.url" => "http://example.com/solr/foo" }
+    writer = Traject::SolrJsonWriter.new(settings)
+    auth = writer.instance_variable_get("@http_client")
+      .www_auth.basic_auth.instance_variable_get("@auth")
+    assert(auth.empty?)
+  end
+
+  it "allows basic authentication setup" do
+    settings = {
+      "solr.url" => "http://example.com/solr/foo",
+      "solr_writer.basic_auth_user" => "foo",
+      "solr_writer.basic_auth_password" => "bar",
+    }
+
+    writer = Traject::SolrJsonWriter.new(settings)
+    auth = writer.instance_variable_get("@http_client")
+      .www_auth.basic_auth.instance_variable_get("@auth")
+    assert(!auth.empty?)
+  end
+
   describe "commit" do
     it "commits on close when set" do
       @writer = create_writer("solr.url" => "http://example.com", "solr_writer.commit_on_close" => "true")


### PR DESCRIPTION
Fixes traject/traject#230

This change allows configuration of basic auth via

`solr_writer.basic_auth_user`
`solr_writer.basic_auth_password`