### PR TITLE
Allow to not error on 409 solr response status.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,11 +2,8 @@
 
 ## Next
 
-*
-
-*
-
-*
+* SolrJsonWriter
+  * Do not raise errors for 409 response status if `solr_writer.ignore_409` is set to true. https://github.com/traject/traject/pull/232
 
 ## 3.2.0
 

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -95,6 +95,8 @@ settings are applied first of all. It's recommended you use `provide`.
 
 * `solr_writer.basic_auth_user`, `solr_writer.basic_auth_password`: Not set by default but when both are set the default writer is configured with basic auth.
 
+* `solr_writer.ignore_409`: Set to `true` If you want traject not to error out when Solr responds with a 409 error. The skipped records will be logged as a warning.
+
 
 ### Dealing with MARC data
 


### PR DESCRIPTION
    Solr can be configured to reject updating a newer document with an older
    document bases on a date field. In the case where this happens instead
    of updating it's newer local document with the older document, solr will
    respond with 409.

    Since this can be an expected behavior traject should allow us to
    configure it not to throw an error and it should not count these as
    skipped towards the calculus of throwing an error when max_skipped is
    reached.

    This configuration is not set by default.