### PR TITLE
Allow class-level configure to be called more than once on class.

### DIFF
--- a/test/indexer/class_level_configuration_test.rb
+++ b/test/indexer/class_level_configuration_test.rb
@@ -25,6 +25,7 @@ describe "Class-level configuration of Indexer sub-class" do
     end
   end
 
+
   before do
     @indexer = TestIndexerSubclass.new
   end
@@ -45,6 +46,28 @@ describe "Class-level configuration of Indexer sub-class" do
     result = @indexer.map_record(Object.new)
     assert_equal ['value', 'from-instance-config'], result['field']
     assert_equal ['from-instance-config'], result["instance_field"]
+  end
+
+  describe "multiple class-level configure" do
+    class MultipleConfigureIndexer < Traject::Indexer
+      configure do
+        to_field "field", literal("value")
+      end
+      configure do
+        to_field "field", literal("value from second configure")
+        to_field "second_call", literal("value from second configure")
+      end
+    end
+
+    before do
+      @indexer = MultipleConfigureIndexer.new
+    end
+
+    it "lets you call class-level configure multiple times and aggregates" do
+      result = @indexer.map_record(Object.new)
+      assert_equal ['value', 'value from second configure'], result['field']
+      assert_equal ['value from second configure'], result['second_call']
+    end
   end
 
   describe "with multi-level subclass" do


### PR DESCRIPTION
It was already possible for superclass to have class-level configure without getting clobbered by sub-class. But we need  to be callable more than once in the same specific class -- in part so we can let mixins do it for reusable/shareable code.

So we make the class-level iVar an array of procs instead of a single proc, with every call to  adding to it.

This is adding some more hacks on top of our already somewhat hacky class-level configure impleementation from https://github.com/traject/traject/pull/213 . But it works. May close #237