### PR TITLE
Run travis tests using MRI 2.7.0 too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 2.4.4
   - 2.5.1
   - 2.6.1
+  - 2.7.0
 # avoid having travis install jdk on MRI builds where we don't need it.
 matrix:
   include:


### PR DESCRIPTION
Seems to produce no deprecation warnings when running tests, hooray