### PR TITLE
Removes extend

### DIFF
--- a/doc/extending.md
+++ b/doc/extending.md
@@ -5,7 +5,7 @@ organize it in files other than traject config files, but then
 use it in traject config files.
 
 You might want to have code local to your traject project; or you
-might want to use ruby gems to share code between projects and developers. 
+might want to use ruby gems to share code between projects and developers.
 A given project may use both of these techniques.
 
 Here are some suggestions for how to do this, along with mention
@@ -17,10 +17,10 @@ of a couple traject features meant to make it easier.
   * Traject `-I` argument command line can be used to list directories to
   add to the load path, similar to the `ruby -I` argument. You
   can then 'require' local project files from the load path.
-  * Modify the ruby `$LOAD_PATH` manually at the top of a traject config file you are loading. 
+  * Modify the ruby `$LOAD_PATH` manually at the top of a traject config file you are loading.
   * NOTE: translation map files in a "./translation_maps" subdir on the load path will be available for to traject.
 * You can use Bundler with traject simply by creating a Gemfile with `bundler init`,
-  and then running command line with `bundle exec traject` or 
+  and then running command line with `bundle exec traject` or
   even `BUNDLE_GEMFILE=path/to/Gemfile bundle exec traject`
 
 ## Custom code local to your project
@@ -41,16 +41,36 @@ directory kept next to your traject config files:
 ~~~
 
 
-The `my_macros.rb` file might contain a simple [macro](./macros.md)
-in a module called `MyMacros`.
+The `my_macros.rb` file might contain a simple [macro](./indexing_rules.md#back-to-macros)
+in a module called `MyMacros` and a method called `my_some_macro`. Let's say it looks like this:
+
+```rb
+module MyMacros
+  def my_some_macro
+    lambda do |_record, accumulator, context|
+      oclc_number = context.output_hash&.dig('oclc_number_ssim')&.first
+      accumulator << "#{oclc_number} my some text"
+    end
+  end
+end
+```
 
 The `my_utility.rb` file might contain, say, a module of utility
 methods, `MyUtility.some_utility`, etc.
+
+```rb
+module MyUtility
+  def some_utility(record)
+    'some text' unless record.fields('505').empty?
+  end
+end
+```
 
 To refer to ruby code from another file, we use the standard
 ruby `require` statement to bring in the files:
 
 ~~~ruby
+
 # config_file.rb
 
 require 'my_macros'
@@ -58,7 +78,6 @@ require 'my_utility'
 
 # Now that MyMacros is available, extend it into the indexer,
 # and use it:
-
 extend MyMacros
 
 to_field "title", my_some_macro
@@ -70,7 +89,7 @@ to_field "title" do |record, accumulator, context|
 end
 ~~~
 
-**But wait!** This won't work yet. Becuase ruby won't be
+**But wait!** This won't work yet. Because ruby won't be
 able to find the file in `requires 'my_macros'`. To fix
 that, we want to add our local `lib` directory to the
 ruby `$LOAD_PATH`, a standard ruby feature.
@@ -97,8 +116,8 @@ That's pretty much it!
 
 What about that translation map? The `$LOAD_PATH` modification
 took care of that too, the Traject::TranslationMap will look
-up translation map definition files 
-in a `./translation_maps` subdir on the load path, as in `./lib/translation_maps` in this case. 
+up translation map definition files
+in a `./translation_maps` subdir on the load path, as in `./lib/translation_maps` in this case.
 
 
 ## Using gems in your traject project
@@ -107,7 +126,7 @@ If there is certain logic that is common between (traject or other)
 projects, it makes sense to put it in a ruby gem.
 
 We won't go into detail about creating ruby gems, but we
-do recomend you use the `bundle gem my_gem_name` command to create
+do recommend you use the `bundle gem my_gem_name` command to create
 a skeleton of your gem
 ([one tutorial here](http://railscasts.com/episodes/245-new-gem-with-bundler?view=asciicast)).
 This will also make available rake commands to install your gem locally
@@ -157,11 +176,11 @@ Be sure to include `gem 'traject'` in the Gemfile.
 Run `bundle install` from the directory with the Gemfile, on any system
 at any time, to make sure specified gems are installed.  (The bundler gem must be already installed on the system.)
 
-**Run traject** with `bundle exec` to have bundler set up the traject environment from your Gemfile. You can `cd` into the directory containing the Gemfile, so bundler can find it: 
+**Run traject** with `bundle exec` to have bundler set up the traject environment from your Gemfile. You can `cd` into the directory containing the Gemfile, so bundler can find it:
 
     $ cd /some/where
     $ bundle exec traject -c some_traject_config.rb ...
-    
+
 Or you can use the BUNDLE_GEMFILE environment variable to tell bundler where
 to find the Gemfile, and run from any directory at all:
 
@@ -169,10 +188,10 @@ to find the Gemfile, and run from any directory at all:
 
 Bundler will make sure the specified versions of all gems are used by
 traject, and also make sure no gems except those specified in the gemfile
-are available to the program, for a reliable reproducible environment. 
+are available to the program, for a reliable reproducible environment.
 
 You still need to `require` the gem in your traject config file;
-then just refer to what it provides in your config code as usual. 
+then just refer to what it provides in your config code as usual.
 
 You should check both the `Gemfile` and the `Gemfile.lock`
 that bundler creates into your source control repo. The
@@ -180,4 +199,4 @@ that bundler creates into your source control repo. The
 gem dependencies are currently being used, so you can get the exact
 same dependency environment on different servers.
 
-See the [bundler documentation](http://bundler.io/#getting-started), or google, for more information. 
+See the [bundler documentation](http://bundler.io/#getting-started), or google, for more information.


### PR DESCRIPTION
I may be off, so please consider this more of a question. If you are `extend`ing the `MyMacros` class then you wouldn't need to namespace it in the call, it'd be just `accumulator << some_utility(record)`. If the code is meant to be called like `accumulator << MyUtility.some_utility(record)` as it is written in the example then `extend` is not required, all you'd need to do that is that `require 'my_utility'`. Right?