### PR TITLE
Replaces missing method reference

### DIFF
--- a/lib/traject/macros/marc21.rb
+++ b/lib/traject/macros/marc21.rb
@@ -15,7 +15,7 @@ module Traject::Macros
     # field/substring specification.
     #
     # First argument is a string spec suitable for the MarcExtractor, see
-    # MarcExtractor::parse_string_spec.
+    # Traject::MarcExtractor::Spec.
     #
     # Second arg is optional options, including options valid on MarcExtractor.new,
     # and others. By default, will de-duplicate results, but see :allow_duplicates

--- a/lib/traject/marc_extractor.rb
+++ b/lib/traject/marc_extractor.rb
@@ -2,9 +2,9 @@ require 'traject/marc_extractor_spec'
 
 module Traject
   # MarcExtractor is a class for extracting lists of strings from a MARC::Record,
-  # according to specifications. See #parse_string_spec for description of string
-  # string arguments used to specify extraction. See #initialize for options
-  # that can be set controlling extraction.
+  # according to specifications. See Traject::MarcExtractor::Spec for description
+  # of string string arguments used to specify extraction. See #initialize for
+  # options that can be set controlling extraction.
   #
   # Examples:
   #


### PR DESCRIPTION
The referenced method was removed in 7ac3806e95820aaa251eba7edd9d33078f38cdac

Is `Traject::MarcExtractor::Spec` the correct new reference?
 
There's another reference to it at line 122:

```rb
    #  * The output of a previous call to MarcExtractor.parse_string_spec(string_spec),
    #    a 'pre-parsed' specification.
```

Not sure what the update would be for that.