### PR TITLE
Do some BASIC integration testing of actual command-line call

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+* `traject -v` and `traject -h` correctly return 0 exit code for success.
+
 *
 
 *

--- a/lib/traject/command_line.rb
+++ b/lib/traject/command_line.rb
@@ -40,11 +40,11 @@ module Traject
     def execute
       if options[:version]
         self.console.puts "traject version #{Traject::VERSION}"
-        return
+        return true
       end
       if options[:help]
         self.console.puts slop.help
-        return
+        return true
       end
 
 

--- a/test/command_line_test.rb
+++ b/test/command_line_test.rb
@@ -1,9 +1,11 @@
 # we mostly unit test with a Traject::Indexer itself and lower-level, but
 # we need at least some basic top-level integration actually command line tests,
 # this is a start, we can add more.
+#
+# Should we be testing Traject::CommandLine as an object instead of/in addition to
+# actually testing shell-out to command line call? Maybe.
 
 require 'test_helper'
-require 'byebug'
 
 describe "Shell out to command line" do
   # just encapsuluate using the minitest capture helper, but also

--- a/test/command_line_test.rb
+++ b/test/command_line_test.rb
@@ -31,5 +31,13 @@ describe "Shell out to command line" do
     assert err.start_with?("traject [options] -c configuration.rb [-c config2.rb] file.mrc")
     assert result.success?
   end
+
+  it "handles bad argument" do
+    out, err, result = execute_with_args("-no-such-arg")
+
+    refute result.success?
+
+    assert err.start_with?("Error: Unknown options -no-such-arg\nExiting...\n")
+  end
 end
 

--- a/test/command_line_test.rb
+++ b/test/command_line_test.rb
@@ -19,6 +19,11 @@ describe "Shell out to command line" do
   end
 
 
+  it "can dispaly version" do
+    out, err, result = execute_with_args("-v")
+    assert_equal err, "traject version #{Traject::VERSION}\n"
+  end
+
   it "can display help text" do
     out, err, result = execute_with_args("-h")
 

--- a/test/command_line_test.rb
+++ b/test/command_line_test.rb
@@ -22,12 +22,14 @@ describe "Shell out to command line" do
   it "can dispaly version" do
     out, err, result = execute_with_args("-v")
     assert_equal err, "traject version #{Traject::VERSION}\n"
+    assert result.success?
   end
 
   it "can display help text" do
     out, err, result = execute_with_args("-h")
 
     assert err.start_with?("traject [options] -c configuration.rb [-c config2.rb] file.mrc")
+    assert result.success?
   end
 end
 

--- a/test/command_line_test.rb
+++ b/test/command_line_test.rb
@@ -1,0 +1,28 @@
+# we mostly unit test with a Traject::Indexer itself and lower-level, but
+# we need at least some basic top-level integration actually command line tests,
+# this is a start, we can add more.
+
+require 'test_helper'
+require 'byebug'
+
+describe "Shell out to command line" do
+  # just encapsuluate using the minitest capture helper, but also
+  # getting and returning exit code
+  #
+  #     out, err, result = execute_with_args("-c configuration")
+  def execute_with_args(args)
+    out, err = capture_subprocess_io do
+      system("./bin/traject #{args}")
+    end
+
+    return out, err, $?
+  end
+
+
+  it "can display help text" do
+    out, err, result = execute_with_args("-h")
+
+    assert err.start_with?("traject [options] -c configuration.rb [-c config2.rb] file.mrc")
+  end
+end
+

--- a/test/command_line_test.rb
+++ b/test/command_line_test.rb
@@ -39,5 +39,13 @@ describe "Shell out to command line" do
 
     assert err.start_with?("Error: Unknown options -no-such-arg\nExiting...\n")
   end
+
+  it "does basic dry run" do
+    out, err, result = execute_with_args("--debug-mode -s one=two -s three=four -c test/test_support/demo_config.rb test/test_support/emptyish_record.marc")
+
+    assert result.success?
+    assert_includes err, "executing with: `--debug-mode -s one=two -s three=four"
+    assert_match /bib_1000165 +author_sort +Collection la/, out
+  end
 end
 


### PR DESCRIPTION
We had none before, an omission. Pre-req to maybe trying to upgrade to slop 4. 

This one is actually testing shell-out to actual command-line calls. We maybe should/could be testing Traject::CommandLine as an object instead or in addition? Probably doesn't matter too much, the `traject` file really does nothing but call out to Traject::CommandLine, should be similar either way.