### PR TITLE
Guards against nil values that crash the map in the DebugWriter

### DIFF
--- a/lib/traject/debug_writer.rb
+++ b/lib/traject/debug_writer.rb
@@ -62,7 +62,7 @@ All records are assumed to have a unique id. You can set which field to look in 
   def serialize(context)
     h       = context.output_hash
     rec_key = record_number(context)
-    lines   = h.keys.sort.map { |k| @format % [rec_key, k, h[k].join(' | ')] }
+    lines   = h.keys.sort.map { |k| @format % [rec_key, k, (h[k] || []).join(' | ')] }
     lines.push "\n"
     lines.join("\n")
   end

--- a/test/debug_writer_test.rb
+++ b/test/debug_writer_test.rb
@@ -73,6 +73,19 @@ describe 'Simple output' do
 
   end
 
+  it "deals ok with nil values" do
+    record_with_nil_value = {"id"=>["2710183"], "title"=>["Manufacturing consent : the political economy of the mass media /"], "xyz"=>nil}
+    @writer.put Traject::Indexer::Context.new(:output_hash => record_with_nil_value)
+    expected = [
+      "#{@id} id #{@id}",
+      "#{@id} title #{@title}",
+      "#{@id} xyz",
+      "\n"
+    ]
+    assert_equal expected.join("\n").gsub(/\s/, ''), @io.string.gsub(/\s/, '')
+    @writer.close
+
+  end
 end
 
 


### PR DESCRIPTION
if the `context.output_hash` has a nil value the map crashes while trying to join the values.  Below is the error that is produces:

```
2021-02-18T10:08:08-05:00 FATAL Traject::CommandLine: Unexpected exception, terminating execution: #<NoMethodError: undefined method `join' for nil:NilClass>
Traceback (most recent call last):
	18: from /Users/correah/.gem/ruby/2.6.6/bin/traject:23:in `<main>'
	17: from /Users/correah/.gem/ruby/2.6.6/bin/traject:23:in `load'
	16: from /Users/correah/.gem/ruby/2.6.6/gems/traject-2.3.1/bin/traject:14:in `<top (required)>'
	15: from /Users/correah/.gem/ruby/2.6.6/gems/traject-2.3.1/lib/traject/command_line.rb:67:in `execute'
	14: from /Users/correah/.gem/ruby/2.6.6/gems/traject-2.3.1/lib/traject/indexer.rb:443:in `process'
	13: from /Users/correah/.gem/ruby/2.6.6/gems/traject-2.3.1/lib/traject/marc_reader.rb:86:in `each'
	12: from /Users/correah/.gem/ruby/2.6.6/gems/marc-1.0.4/lib/marc/xml_parsers.rb:116:in `each'
	11: from /Users/correah/.gem/ruby/2.6.6/gems/nokogiri-1.11.1-x86_64-darwin/lib/nokogiri/xml/sax/parser.rb:82:in `parse'
	10: from /Users/correah/.gem/ruby/2.6.6/gems/nokogiri-1.11.1-x86_64-darwin/lib/nokogiri/xml/sax/parser.rb:94:in `parse_io'
	 9: from /Users/correah/.gem/ruby/2.6.6/gems/nokogiri-1.11.1-x86_64-darwin/lib/nokogiri/xml/sax/parser.rb:94:in `parse_with'
	 8: from /Users/correah/.gem/ruby/2.6.6/gems/marc-1.0.4/lib/marc/xml_parsers.rb:76:in `end_element_namespace'
	 7: from /Users/correah/.gem/ruby/2.6.6/gems/marc-1.0.4/lib/marc/xml_parsers.rb:41:in `yield_record'
	 6: from /Users/correah/.gem/ruby/2.6.6/gems/traject-2.3.1/lib/traject/indexer.rb:473:in `block in process'
	 5: from /Users/correah/.gem/ruby/2.6.6/gems/traject-2.3.1/lib/traject/thread_pool.rb:116:in `maybe_in_thread_pool'
	 4: from /Users/correah/.gem/ruby/2.6.6/gems/traject-2.3.1/lib/traject/indexer.rb:478:in `block (2 levels) in process'
	 3: from /Users/correah/.gem/ruby/2.6.6/gems/traject-2.3.1/lib/traject/line_writer.rb:39:in `put'
	 2: from /Users/correah/.gem/ruby/2.6.6/gems/traject-2.3.1/lib/traject/debug_writer.rb:78:in `serialize'
	 1: from /Users/correah/.gem/ruby/2.6.6/gems/traject-2.3.1/lib/traject/debug_writer.rb:78:in `map'
/Users/correah/.gem/ruby/2.6.6/gems/traject-2.3.1/lib/traject/debug_writer.rb:78:in `block in serialize': undefined method `join' for nil:NilClass (NoMethodError)
```

This PR prevents the crash.