### PR TITLE
Allow http gem 5.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 
 * Tiny backward compat changes for ruby 3.0 compat. https://github.com/traject/traject/pull/263
 
-*
+* Allow gem `http` 5.x in gemspec. https://github.com/traject/traject/pull/269
 
 ## 3.5.0
 

--- a/traject.gemspec
+++ b/traject.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "yell" # logging
   spec.add_dependency "dot-properties", ">= 0.1.1" # reading java style .properties
   spec.add_dependency "httpclient", "~> 2.5"
-  spec.add_dependency "http", ">= 3.0", "< 5" # used in oai_pmh_reader, may use more extensively in future instead of httpclient
+  spec.add_dependency "http", ">= 3.0", "< 6" # used in oai_pmh_reader, may use more extensively in future instead of httpclient
   spec.add_dependency 'marc-fastxmlwriter', '~>1.0' # fast marc->xml
   spec.add_dependency "nokogiri", "~> 1.9" # NokogiriIndexer
 


### PR DESCRIPTION
Was released recently. No traject code changes are needed, traject's use of the http gem is simple and works in multiple versions. Just relaxing gemspec to allow consuming apps to use the http gem version of their choice including latest.