### PR TITLE
passing with Jruby 9.1, and better failure messages on command line test failures

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -16,10 +16,19 @@ jobs:
     name: Ruby ${{ matrix.ruby }}
     steps:
     - uses: actions/checkout@v2
+
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
+
+    - name: set JAVA_OPTS for jruby-9.1
+      run: echo 'JAVA_OPTS="--add-opens java.base/java.security.cert=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED --add-opens java.base/java.util.zip=ALL-UNNAMED"' >> $GITHUB_ENV
+      if: ${{ matrix.ruby == 'jruby-9.1' }}
+      # https://github.com/jruby/jruby/issues/4834
+      # Still seems to be an issue in jruby-9.1, but not 9.2
+      # https://github.community/t/conditional-setting-of-env-variables-in-gh-actions/179650
+
     - name: Install dependencies
       run: bundle install --jobs 4 --retry 3
     - name: Run tests

--- a/test/command_line_test.rb
+++ b/test/command_line_test.rb
@@ -22,15 +22,16 @@ describe "Shell out to command line" do
 
   it "can display version" do
     out, err, result = execute_with_args("-v")
+
+    assert result.success?, "Expected subprocess exit code to be success.\nSTDERR:\n#{err}\n\nSTDOUT:\n#{out}"
     assert_equal err, "traject version #{Traject::VERSION}\n"
-    assert result.success?
   end
 
   it "can display help text" do
     out, err, result = execute_with_args("-h")
 
+    assert result.success?, "Expected subprocess exit code to be success.\nSTDERR:\n#{err}\n\nSTDOUT:\n#{out}"
     assert err.start_with?("traject [options] -c configuration.rb [-c config2.rb] file.mrc")
-    assert result.success?
   end
 
   it "handles bad argument" do
@@ -43,7 +44,7 @@ describe "Shell out to command line" do
   it "does basic dry run" do
     out, err, result = execute_with_args("--debug-mode -s one=two -s three=four -c test/test_support/demo_config.rb test/test_support/emptyish_record.marc")
 
-    assert result.success?
+    assert result.success?, "Expected subprocess exit code to be success.\nSTDERR:\n#{err}\n\nSTDOUT:\n#{out}"
     assert_includes err, "executing with: `--debug-mode -s one=two -s three=four"
     assert_match /bib_1000165 +author_sort +Collection la/, out
   end


### PR DESCRIPTION
JRuby 9.1 is out of support, but if we can we want to keep tests passing with it, because ideally dropping support would be a major version bump for traject. 

We started having a problem getting tests to pass under JRuby 9.1 and Java 11. Not sure why these didn't happen before, but Java is printing `WARNING` messages in console, that mess up our tests that test console output. 

(Was initially hard to reproduce locally, because does not repro with Java 1.8, only Java 9+). 

Setting some JAVA_OPTS can disable these warnings. We only do so in our .github actions setup, but ONLY for JRuby 9.1, as a workaround. Not needed in Jruby 9.2, and not set, and should work without warnings in Jruby 9.2. This is all really a JRuby issue not a traject issue, but we just want to keep CI passing .

https://github.com/jruby/jruby/issues/4834

