### PR TITLE
Provide a fallback for a missing second date

### DIFF
--- a/lib/traject/macros/marc21_semantics.rb
+++ b/lib/traject/macros/marc21_semantics.rb
@@ -327,7 +327,11 @@ module Traject::Macros
       if field008 && field008.length >= 11
         date_type = field008.slice(6)
         date1_str = field008.slice(7,4)
-        date2_str = field008.slice(11, 4) if field008.length > 15
+        if field008.length > 15
+          date2_str = field008.slice(11, 4)
+        else
+          date2_str = date1_str
+        end
 
         # for date_type q=questionable, we have a range.
         if (date_type == 'q')


### PR DESCRIPTION
If the record 008 date states a range of dates (q) but the second date is
missing, date2_str is undefined, and it causes an exception:

 Exception: NoMethodError: undefined method `sub' for nil:NilClass
 [...]/vendor/bundle/ruby/2.7.0/gems/traject-3.6.0/lib/traject/macros/marc21_semantics.rb:336:in
 `publication_date'

Assign date2_str the same value than date1_str as a fallback.