### PR TITLE
Include Solr-reported error message in our exception message

### DIFF
--- a/lib/traject/solr_json_writer.rb
+++ b/lib/traject/solr_json_writer.rb
@@ -431,8 +431,26 @@ class Traject::SolrJsonWriter
     attr_reader :response
 
     def initialize(msg, response = nil) # :nodoc:
+      solr_error = find_solr_error(response)
+      msg += ": #{solr_error}" if solr_error
+
       super(msg)
+
       @response = response
+    end
+
+    private
+
+    # If we can get the error out of a JSON response, please do,
+    # to include in error message.
+    def find_solr_error(response)
+      return nil unless response && response.body && response.content_type&.start_with?("application/json")
+
+      parsed = JSON.parse(response.body)
+
+      parsed && parsed.dig("error", "msg")
+    rescue JSON::ParserError
+      return nil
     end
   end
 


### PR DESCRIPTION
When we can parse it in JSON, do so, and include it in our exception message. When we can't, silently just accept we can't.

It is so much more convenient to have access to this error message! Say, for instance: 

"ERROR: [doc=2z10wq43q] Error adding field 'earliest_date'='[1588]' msg=Invalid Date String:'1588'"
