### PR TITLE
SolrJsonWriter: HTTPClient should use OS certs instead of packaged ones

### DIFF
--- a/lib/traject/solr_json_writer.rb
+++ b/lib/traject/solr_json_writer.rb
@@ -86,6 +86,9 @@ require 'concurrent' # for atomic_fixnum
 # * solr_json_writer.http_client Mainly intended for testing, set your own HTTPClient
 #   or mock object to be used for HTTP.
 #
+# * solr_json_writer.use_packaged_certs: unlikely to be needed, set to true for legacy
+#   behavior, to use packaged HTTPClient gem ssl certs. https://github.com/nahi/httpclient/issues/445
+#
 class Traject::SolrJsonWriter
   include Traject::QualifiedConstGet
 
@@ -118,6 +121,15 @@ class Traject::SolrJsonWriter
       @settings["solr_json_writer.http_client"]
     else
       client = HTTPClient.new
+
+      # By default we'll use teh host OS SSL certs, but you can use
+      # setting solr_json_writer.use_packaged_certs to true or "true"
+      # to go back to previous behavior if you have a perverse reason to.
+      # https://github.com/nahi/httpclient/issues/445
+      unless @settings["solr_json_writer.use_packaged_certs"].to_s == "true"
+        client.ssl_config.set_default_paths
+      end
+
       if @settings["solr_writer.http_timeout"]
         client.connect_timeout = client.receive_timeout = client.send_timeout = @settings["solr_writer.http_timeout"]
       end


### PR DESCRIPTION
If the host app is passing in a HTTPClient instance, this won't effect it. But that's probably a rarely used feature, and the host app is responsible for configuring the HTTPClient similarly in that case.

Otherwise, tell HTTPClient to _not_ do it's insane default of using a 6-year-old cert package, but just to use the cert package on the OS. The bundled with HTTPClient cert package no longer works with letsencrypt certs. This change should resolve that for people using standard defaults.

If someone really needs the old behavior, they can set setting `"solr_json_writer.use_packaged_certs"` to `true` or `"true"`. Just in case there's some edge case reason this change could break things and someone would need to go back to previous behavior.  I am comfortable releasing this change in a minor release, considering it a bugfix.

Ref #285

and https://github.com/nahi/httpclient/issues/445
