### PR TITLE
Use old ruby-marc when running on old rubies, to get CI to pass

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,11 @@ group :debug do
   gem "ruby-debug", :platform => "jruby"
   gem "byebug", :platform => "mri"
 end
+
+# ruby-marc stopped supporting ruby 2.3 and 2.4 in newer 1.x versions,
+# while we would still like to support those old versions. When running
+# CI, run with older ruby-marc that still supports them.
+ruby_version_parts = RUBY_VERSION.split(".")
+if ruby_version_parts[0] == "2" && ruby_version_parts[1].to_i < 5
+  gem "marc", "< 1.2.0"
+end


### PR DESCRIPTION
Newer ruby-marc stopped supporting old rubies, but traject still wants to. We can, so long as caller uses a ruby-marc compat with old ruby.

Closes #287

What do you think @billdueber?

I don't really have a dog in the race for ruby-marc anymore (I don't use MARC data currently), but as one of the primary ruby-marc maintainers, @billdueber , I'm also interested in your opinion on if ruby-marc dropping support for ruby 2.3/2.4 in 1.x was intentional or accidental. It's probably not too late to restore support at this point -- that "rescue" issue is easy to solve, just needs some explicit `begin`/`end`, not sure if any other things crept in without ruby-marc CI on old versions, but prob not too much ruby-marc hasnt' like had a ton of changes or anything. 
