### PR TITLE
Bug fix for the `#filing_version` logic

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,14 @@
 
 *
 
-*
+## 3.8.2
+
+Bug fix for the `#filing_version` logic, which was incorrectly assuming the 
+first subfield in a field would hold content (e.g., `$a`) and thus failed
+when it held a pointer to a linking field (e.g., `$6 245-01`)
+
+```
+
 
 ## 3.8.1
 

--- a/lib/traject/macros/marc21_semantics.rb
+++ b/lib/traject/macros/marc21_semantics.rb
@@ -167,7 +167,13 @@ module Traject::Macros
       # (b) include the first subfield in the record
 
       subs = spec.subfields
-      return str unless subs && subs.include?(field.subfields[0].code)
+
+      # Get the code for the first alphabetic subfield, which would be
+      # the one getting characters shifted off
+
+      first_alpha_code = field.subfields.first{|sf| sf.code =~ /[a-z]/}.code
+
+      return str unless subs && subs.include?(first_alpha_code)
 
       # OK. If we got this far we actually need to strip characters off the string
 

--- a/lib/traject/version.rb
+++ b/lib/traject/version.rb
@@ -1,3 +1,3 @@
 module Traject
-  VERSION = "3.8.1"
+  VERSION = "3.8.2"
 end

--- a/test/indexer/macros/macros_marc21_semantics_test.rb
+++ b/test/indexer/macros/macros_marc21_semantics_test.rb
@@ -87,8 +87,9 @@ describe "Traject::Macros::Marc21Semantics" do
 
       assert_equal ["Business renaissance quarterly [electronic resource]."], output["author_sort"]
       assert_equal [""], @indexer.map_record(empty_record)['author_sort']
-
     end
+
+
   end
 
   describe "marc_sortable_title" do
@@ -107,6 +108,16 @@ describe "Traject::Macros::Marc21Semantics" do
 
       assert_equal ["Business renaissance quarterly"], output["title_sort"]
     end
+
+    it "respects non-filing when the first subfield isn't alphabetic" do
+      @record = MARC::Reader.new(support_file_path  "the_business_ren.marc").first
+      @record.fields("245").first.subfields.unshift MARC::Subfield.new("6", "245-03")
+      output = @indexer.map_record(@record)
+      assert_equal ["Business renaissance quarterly"], output["title_sort"]
+
+
+    end
+
     it "works with a record with no 245$ab" do
       @record = MARC::Reader.new(support_file_path  "245_no_ab.marc").to_a.first
       output = @indexer.map_record(@record)


### PR DESCRIPTION
Derivation of the filing version assuming the first subfield in a field would hold content (e.g., `$a`) and thus failed when it held a pointer to a linking field (e.g., `$6 245-01`). Now do checks and modification of the first _alphabetic_ subfield. 

Fixed the code, added a test, changed CHANGES.md and upped the patch version.