### PR TITLE
Add csv dependency

### DIFF
--- a/traject.gemspec
+++ b/traject.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
 
 
   spec.add_dependency "concurrent-ruby", ">= 0.8.0"
+  spec.add_dependency "csv"
   spec.add_dependency "marc", "~> 1.0"
 
   spec.add_dependency "hashie", ">= 3.1", "< 6" # used for Indexer#settings


### PR DESCRIPTION
CSV is being removed from the standard library in ruby 3.4:

> warning: csv was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.