### PR TITLE
Update tested rubies to eliminate MRI < 2.7 and jruby 9.2, and add MRI 3.4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', 'jruby-9.2', 'jruby-9.3', 'jruby-9.4' ]
+        ruby: [ '2.7', '3.0', '3.1', '3.2', '3.3', '3.4', 'jruby-9.3', 'jruby-9.4' ]
     name: Ruby ${{ matrix.ruby }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
According to the [jetbrains folks](https://www.jetbrains.com/lp/devecosystem-2023/ruby/), which seems as good a source as any (i.e., probably not great), more than 30% of their survey participants still use 2.7 somewhere, so we'll keep that even though it's well past EOL.

MRI 3.0 is past EOL, too, but I don't know enough about what they broke in the subsequent point releases, and it's not super aggressive to keep them in.

JRuby has a more aggressive EOL schedule -- 9.2 isn't even installable via `apt` on ubuntu, and 9.3 was supposed to go EOL at the end of 2023. I've only eliminated 9.2 in this push. 
