### PR TITLE
pass CI for ruby 3.4

### DIFF
--- a/test/indexer/error_handler_test.rb
+++ b/test/indexer/error_handler_test.rb
@@ -21,7 +21,7 @@ describe 'Custom mapping error handler' do
     end
 
     assert_equal "I just like raising errors", e.message
-    assert output.string =~ /while executing \(to_field \"id\" at .*error_handler_test.rb:\d+\)/
+    assert output.string =~ /while executing \(to_field \"id\" at .*error_handler_test.rb:\d+.*\)/
     assert output.string =~ /CustomFakeException: I just like raising errors/
   end
 
@@ -38,7 +38,7 @@ describe 'Custom mapping error handler' do
       end
     end
     e = assert_raises(CustomFakeException) { indexer.map_record({}) }
-    assert e.message =~ /\(to_field \"id\" at .*error_handler_test.rb:\d+\)/
+    assert e.message =~ /\(to_field \"id\" at .*error_handler_test.rb:\d+.*\)/
   end
 
   it "custom handler can skip and continue" do

--- a/traject.gemspec
+++ b/traject.gemspec
@@ -30,6 +30,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "yell" # logging
   spec.add_dependency "dot-properties", ">= 0.1.1" # reading java style .properties
   spec.add_dependency "httpclient", "~> 2.5"
+  spec.add_dependency "mutex_m"  # httpclient has an undelcared dep needed in ruby 3.4+, not yet released. https://github.com/nahi/httpclient/pull/455
+
   spec.add_dependency "http", ">= 3.0", "< 6" # used in oai_pmh_reader, may use more extensively in future instead of httpclient
   spec.add_dependency 'marc-fastxmlwriter', '~>1.0' # fast marc->xml
   spec.add_dependency "nokogiri", "~> 1.9" # NokogiriIndexer


### PR DESCRIPTION
### 1. Add mutex_m as an explicit dependency, workaround httpclient missing dep in ruby 3.4

As of ruby 3.4, mutex_m (currently at 0.3.0 :( ) is a "bundled gem", meaning it needs to be declared as explicit dependency. The abandon-maintained httpclient uses mutex_m, but does not declare it as a dependency. This workaround can make our use of httpclient pass CI and work in ruby 3.4.


### 2. Fix exception message assertions to pass ruby 3.4 too

ruby 3.4 puts some additional content about nested exception before close-paren, let regex in assertion tolerate it. 
