### PR TITLE
pass CI in ruby 3.4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,8 +19,7 @@ jobs:
           - '3.2'
           - '3.3'
           - '3.4'
-          - 'jruby-9.3'
-          - 'jruby-9.4'
+          - 'jruby-10.0'
     name: Ruby ${{ matrix.ruby }}
     steps:
     - uses: actions/checkout@v2

--- a/traject.gemspec
+++ b/traject.gemspec
@@ -42,4 +42,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "rspec-mocks", '~> 3.4'
+  # rspec-mocks no longer includes rspec-core as a dependency, we need to include it.
+  spec.add_development_dependency "rspec-core", '~> 3.4'
 end

--- a/traject.gemspec
+++ b/traject.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dot-properties", ">= 0.1.1" # reading java style .properties
   spec.add_dependency "httpclient", "~> 2.5"
   spec.add_dependency "mutex_m"  # httpclient has an undelcared dep needed in ruby 3.4+, not yet released. https://github.com/nahi/httpclient/pull/455
+  spec.add_dependency "base64" # no longer inlcuded in stdlib
 
   spec.add_dependency "http", ">= 3.0", "< 7" # used in oai_pmh_reader, may use more extensively in future instead of httpclient
   spec.add_dependency 'marc-fastxmlwriter', '~>1.0' # fast marc->xml


### PR DESCRIPTION
We have CI passing in ruby 3.4, basically just required adding some dependencies that were moved out of default ruby or otherwise required updating. 

I wanted to get passing in JRuby, but it's beyond me -- I do not use jruby. 

> Traject::ExperimentalNokogiriStreamingReader::with namespaces::floating path#test_0001_reads:
Java::OrgW3cDom::DOMException: NAMESPACE_ERR: An attempt is made to create or change an object in a way which is incorrect with regard to namespaces.

I did drop old jrubies from CI, and added only jruby 10.0, which is ruby 3.4 compatible. It isn't really feasible to support very old jrubies, jruby doesn't work that way.  Jruby 10.1 is also out supporting ruby 4.0, which we don't yet support, will have that in subseuqent ticket. 

@billdueber thoughts on what we should do with jruby?  Drop from CI or at least from mandatory passing of CI? No longer support Jruby?  You still use traject with jruby? Know of others who do?