### PR TITLE
avoid ruby 3.4 warning for "literal string will be frozen in the future"

### DIFF
--- a/lib/traject/csv_writer.rb
+++ b/lib/traject/csv_writer.rb
@@ -5,7 +5,6 @@ require 'csv'
 # Use DelimitedWriter for non-CSV lines (e.g., tab-delimited)
 #
 #
-
 class Traject::CSVWriter < Traject::DelimitedWriter
 
   def initialize(*args)
@@ -26,6 +25,11 @@ class Traject::CSVWriter < Traject::DelimitedWriter
   # Let CSV take care of the comma escaping
   def escape(x)
     x = x.to_s
+
+    if x.frozen?
+      x = x.dup
+    end
+
     x.gsub! internal_delimiter, @eidelim
     x
   end

--- a/lib/traject/delimited_writer.rb
+++ b/lib/traject/delimited_writer.rb
@@ -20,7 +20,7 @@ require 'traject/line_writer'
 # escape delimiters/internal_delimiters in the following way:
 #  * If the delimiter is a tab, replace tabs in values with a single space
 #  * If the delimiter is anything else, prefix it with a backslash
-
+#
 class Traject::DelimitedWriter < Traject::LineWriter
 
   attr_reader :delimiter,  :internal_delimiter, :edelim, :eidelim
@@ -83,6 +83,11 @@ class Traject::DelimitedWriter < Traject::LineWriter
   # Escape the delimiters in whatever way has been defined
   def escape(x)
     x = x.to_s
+
+    if x.frozen?
+      x = x.dup
+    end
+
     x.gsub! @delimiter, @edelim if @delimiter
     x.gsub! @internal_delimiter, @eidelim
     x

--- a/lib/traject/experimental_nokogiri_streaming_reader.rb
+++ b/lib/traject/experimental_nokogiri_streaming_reader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Traject
   # An EXPERIMENTAL HALF-FINISHED implementation of a streaming/pull reader using Nokogiri.
   # Not ready for use, not stable API, could go away.
@@ -134,7 +136,7 @@ module Traject
         @inverted_namespaces  = namespaces.invert
         @clipboard = clipboard
         # We're guessing using a string will be more efficient than an array
-        @current_path         = ""
+        @current_path         = +""
         @floating             = false
 
         @path_spec, @floating = parse_path(str_spec)

--- a/lib/traject/indexer/context.rb
+++ b/lib/traject/indexer/context.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Represents the context of a specific record being indexed, passed
 # to indexing logic blocks
 #
@@ -57,7 +59,7 @@ class Traject::Indexer
     # a string label that can be used to refer to a particular record in log messages and
     # exceptions. Includes various parts depending on what we got.
     def record_inspect
-      str = "<"
+      str = +"<"
 
       str << "record ##{position}" if position
 

--- a/lib/traject/macros/marc21_semantics.rb
+++ b/lib/traject/macros/marc21_semantics.rb
@@ -1,4 +1,5 @@
 # Encoding: UTF-8
+# frozen_string_literal: true
 
 require 'traject/marc_extractor'
 
@@ -570,7 +571,7 @@ module Traject::Macros
     # associated with the content of subfield $v, $x, $y, and $z."
     # http://www.loc.gov/marc/bibliographic/bd600.html
     def self.assemble_lcsh(marc_field, subd_separator = " — ", other_separator = " ")
-      str = ""
+      str = +""
       subd_prefix_codes = %w{v x y z}
 
 

--- a/test/delimited_writer_test.rb
+++ b/test/delimited_writer_test.rb
@@ -1,4 +1,5 @@
 # Encoding: UTF-8
+# frozen_string_literal: true
 
 require 'test_helper'
 require 'stringio'


### PR DESCRIPTION
"literal string will be frozen in the future" warning for string literals that in future ruby version will be automatically frozen, but our tests modify. 

Fixed in our code. The way I fixed for `escape` method is the most unusual, but I think it's the only good way to do it?  Feedback welcome, @billdueber ?  Other places were fairly straightforward. 

Warnings remain for two dependencies: 1) fastxmlwriter (only used in a benchmark test), 2) another still remains from "yell" (will submit a PR to yell). 


- update context with frozen_string_literal default
- frozen_string_literal in experimental_nokogiri_streaming_reader
- frozen_string_literal in marc21_semantics.rb
- Fix frozen string warnings for 'escape' in Delimited writers. Not totally sure in what cases this is necessary in non-test code, but this seem safest based on it being necessary in test code
