### PR TITLE
Pass CI on Ruby 3.4, update JRuby versions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,8 +19,7 @@ jobs:
           - '3.2'
           - '3.3'
           - '3.4'
-          - 'jruby-9.3'
-          - 'jruby-9.4'
+          - 'jruby-10.0'
     name: Ruby ${{ matrix.ruby }}
     steps:
     - uses: actions/checkout@v2

--- a/traject.gemspec
+++ b/traject.gemspec
@@ -42,4 +42,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "rspec-mocks", '~> 3.4'
+  # rspec-mocks no longer includes rspec-core as a dependency, we need to include it.
+  spec.add_development_dependency "rspec-core", '~> 3.4'
 end

--- a/traject.gemspec
+++ b/traject.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dot-properties", ">= 0.1.1" # reading java style .properties
   spec.add_dependency "httpclient", "~> 2.5"
   spec.add_dependency "mutex_m"  # httpclient has an undelcared dep needed in ruby 3.4+, not yet released. https://github.com/nahi/httpclient/pull/455
+  spec.add_dependency "base64" # no longer inlcuded in stdlib
 
   spec.add_dependency "http", ">= 3.0", "< 7" # used in oai_pmh_reader, may use more extensively in future instead of httpclient
   spec.add_dependency 'marc-fastxmlwriter', '~>1.0' # fast marc->xml


### PR DESCRIPTION
Get tests to pass on ruby 3.4, which requires adding a couple things to Gemfile. 

Update JRuby versions tested -- test only JRuby 10.0 that is ruby 3.4 compat. It isn't really feasible to keep supporting very old JRuby. There is also a Jruby 10.1 just released for ruby 4.0 compat, that will come in a future PR -- although if we can't get JRuby to pass at all, I dunno. 

- update CI to drop old Jruby's that can't really be supported. Only 10.0 for ruby 3.4 compat
- base64 now bundled gem that needs to be in gemspec in ruby 3.4
- rspec-core now needs to be individually listed to use rspec-mocks, it seems
