### PR TITLE
Support and test on Ruby 4.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,9 @@ jobs:
           - '3.2'
           - '3.3'
           - '3.4'
+          - '4.0'
           - 'jruby-10.0'
+          - 'jruby-10.1'
     name: Ruby ${{ matrix.ruby }}
     steps:
     - uses: actions/checkout@v2

--- a/lib/traject/oai_pmh_nokogiri_reader.rb
+++ b/lib/traject/oai_pmh_nokogiri_reader.rb
@@ -1,5 +1,4 @@
 require 'uri'
-require 'cgi'
 require 'http'
 
 module Traject
@@ -54,7 +53,7 @@ module Traject
     end
 
     def start_url_verb
-      @start_url_verb ||= (array = CGI.parse(URI.parse(start_url).query)["verb"]) && array.first
+      @start_url_verb ||= URI.decode_www_form(URI.parse(start_url).query).to_h["verb"]
     end
 
     def extra_xpath_hooks
@@ -94,7 +93,7 @@ module Traject
       # resumption URL is just original verb with resumption token, that seems to be
       # the oai-pmh spec.
       parsed_uri = URI.parse(start_url)
-      parsed_uri.query = "verb=#{CGI.escape start_url_verb}&resumptionToken=#{CGI.escape resumption_token}"
+      parsed_uri.query = "verb=#{URI.encode_www_form_component start_url_verb}&resumptionToken=#{URI.encode_www_form_component resumption_token}"
       parsed_uri.to_s
     end
 

--- a/traject.gemspec
+++ b/traject.gemspec
@@ -37,8 +37,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'marc-fastxmlwriter', '~>1.0' # fast marc->xml
   spec.add_dependency "nokogiri", "~> 1.9" # NokogiriIndexer
 
-  spec.add_development_dependency 'bundler', '>= 1.7', '< 3'
-
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "rspec-mocks", '~> 3.4'


### PR DESCRIPTION
- remove bundler from gemspec
- Replace CGI.* methods removed from ruby 4.0 with URI.* methods
- test on ruby 4.0 and corresponding jruby 10.1
